### PR TITLE
Version2.0 imagingHandler.py mostly implemented

### DIFF
--- a/phangsPipeline/casaImagingRoutines.py
+++ b/phangsPipeline/casaImagingRoutines.py
@@ -17,12 +17,20 @@ logger.setLevel(logging.DEBUG)
 import analysisUtils as au
 
 # CASA stuff
-import casaStuff as casa
+import casaStuff
+
+from casaMaskingRoutines import signal_mask
+from casaMaskingRoutines import stat_clean_cube
 
 # Pipeline versionining
 from pipelineVersion import version as pipeVer
 
 #endregion
+
+
+
+
+
 
 #region Setting up imaging
 
@@ -38,7 +46,7 @@ def estimate_cell_and_imsize(
     """
 
     if os.path.isdir(in_file) == False:
-        print "File not found."
+        logger.error('Error! The input file "'+in_file+'" was not found!')
         return
     
     valid_sizes = []
@@ -190,3 +198,565 @@ def export_imaging_to_fits(
 
 
 #endregion
+
+
+
+
+
+
+
+# &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+# Routines to characterize and manipulate cubes
+# &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+# 
+# stat_clean_cube is now in casaMaskingRoutines.py
+# 
+#def stat_clean_cube(cube_file=None):
+#    """
+#    Calculate statistics for an image cube.
+#    """
+#    if cube_file == None:
+#        logger.info("No cube file specified. Returning")
+#        return
+#    imstat_dict = imstat(cube_file)
+#    
+#    return imstat_dict
+
+
+def save_copy_of_cube(
+    input_root=None,
+    output_root=None):
+    """
+    Copy a cube to a new name. Used to make a backup copy. Overwrites
+    the previous cube of that name.
+    """
+
+    wipe_cube(output_root)
+    
+    os.system('cp -r '+input_root+'.image '+output_root+'.image')
+    os.system('cp -r '+input_root+'.model '+output_root+'.model')
+    os.system('cp -r '+input_root+'.mask '+output_root+'.mask')
+    os.system('cp -r '+input_root+'.pb '+output_root+'.pb')
+    os.system('cp -r '+input_root+'.psf '+output_root+'.psf')
+    os.system('cp -r '+input_root+'.residual '+output_root+'.residual')
+    os.system('cp -r '+input_root+'.psf '+output_root+'.weight')
+    os.system('cp -r '+input_root+'.residual '+output_root+'.sumwt')
+
+
+def wipe_cube(
+    cube_root=None):
+    """
+    Wipe files associated with a cube.
+    """
+    if cube_root == None:
+        return
+    os.system('rm -rf '+cube_root+'.image')
+    os.system('rm -rf '+cube_root+'.model')
+    os.system('rm -rf '+cube_root+'.mask')
+    os.system('rm -rf '+cube_root+'.pb')
+    os.system('rm -rf '+cube_root+'.psf')
+    os.system('rm -rf '+cube_root+'.residual')
+    os.system('rm -rf '+cube_root+'.weight')
+    os.system('rm -rf '+cube_root+'.sumwt')
+
+
+def replace_cube_with_copy(
+    to_root=None,
+    from_root=None):
+    """
+    Replace a cube with a copy.
+    """
+    
+    wipe_cube(to_root)
+    
+    os.system('cp -r '+from_root+'.image '+to_root+'.image')
+    os.system('cp -r '+from_root+'.model '+to_root+'.model')
+    os.system('cp -r '+from_root+'.mask '+to_root+'.mask')
+    os.system('cp -r '+from_root+'.pb '+to_root+'.pb')
+    os.system('cp -r '+from_root+'.psf '+to_root+'.psf')
+    os.system('cp -r '+from_root+'.residual '+to_root+'.residual')
+    os.system('cp -r '+from_root+'.psf '+to_root+'.weight')
+    os.system('cp -r '+from_root+'.residual '+to_root+'.sumwt')
+
+
+def export_to_fits(
+    cube_root=None,
+    bitpix=-32):
+    """
+    Export the various products associated with a CASA cube to FITS.
+    """
+    
+    casaStuff.exportfits(\
+               imagename=cube_root+'.image',
+               fitsimage=cube_root+'.fits',
+               velocity=True, overwrite=True, dropstokes=True, 
+               dropdeg=True, bitpix=bitpix)
+
+    casaStuff.exportfits(\
+               imagename=cube_root+'.model',
+               fitsimage=cube_root+'_model.fits',
+               velocity=True, overwrite=True, dropstokes=True, 
+               dropdeg=True, bitpix=bitpix)
+
+    casaStuff.exportfits(\
+               imagename=cube_root+'.residual',
+               fitsimage=cube_root+'_residual.fits',
+               velocity=True, overwrite=True, dropstokes=True, 
+               dropdeg=True, bitpix=bitpix)
+
+    casaStuff.exportfits(\
+               imagename=cube_root+'.mask',
+               fitsimage=cube_root+'_mask.fits',
+               velocity=True, overwrite=True, dropstokes=True, 
+               dropdeg=True, bitpix=bitpix)
+    
+    casaStuff.exportfits(\
+               imagename=cube_root+'.pb',
+               fitsimage=cube_root+'_pb.fits',
+               velocity=True, overwrite=True, dropstokes=True, 
+               dropdeg=True, bitpix=bitpix)
+    
+    return
+
+
+
+
+
+
+
+
+
+
+#region class CleanCall
+
+class CleanCall:
+    
+    def __init__(self):
+        self.vis = None
+        self.antenna = ""
+        self.image_root = None
+        self.phase_center = ""
+        self.image_size = None
+        self.cell_size = None
+        self.restfreq_ghz = -1.0
+        self.calcres = True
+        self.calcpsf = True
+        self.specmode = 'cube'
+        self.deconvolver = 'hogbom'
+        self.threshold = '0.0mJy/beam'
+        self.scales_as_pix = [0]
+        self.scales_as_angle = None
+        self.smallscalebias = 0.9
+        self.briggs_weight = 0.5
+        self.niter = 0
+        self.cycle_niter = 200
+        self.minpsffraction = 0.5
+        self.pblimit = 0.25
+        self.uvtaper = None
+        self.restoringbeam = 'common'
+        self.usemask = 'user'
+        self.mask = ''
+        self.interactive = False
+        self.rest = False
+        self.logfile = None
+        self.clean_mask_file = None
+
+    def execute(self):
+        """
+        Execute the clean call.
+        """
+    
+        if self.vis == None:
+            logger.info("No visibility. Returning.")
+            return    
+
+        if os.path.isdir(self.vis) == False:
+            logger.info("Visibility file not found. Returning.")
+            return
+        
+        if self.cell_size == None or self.image_size == None:
+            logger.info("Estimating cell and image size.")
+            cell_size, x_size, y_size = \
+                estimate_cell_and_imsize(self.vis, oversamp=5)
+            self.cell_size = cell_size
+            self.image_size = [x_size, y_size]
+
+        if self.restfreq_ghz < 0:
+            restfreq_str = ''
+        else:
+            restfreq_str = str(self.restfreq_ghz)+'GHz'
+
+        if self.logfile != None:
+            oldlogfile = casaStuff.casalog.logfile()
+            casaStuff.casalog.setlogfile(self.logfile)
+
+        if self.uvtaper == None:
+            uv_taper_string = ''
+        else:
+            uv_taper_string = [str(self.uvtaper)+'arcsec',str(self.uvtaper)+'arcsec','0deg']
+
+        if self.reset:
+            logger.info("Wiping previous versions of the cube.")
+            wipe_cube(self.image_root)
+
+        casaStuff.tclean(\
+               vis=self.vis,
+               imagename=self.image_root,
+               phasecenter=self.phase_center,
+               cell=self.cell_size,
+               imsize=self.image_size,
+               gridder='mosaic',
+               # Selection
+               #antenna=self.antenna,
+               # Spectral axis
+               specmode=self.specmode,
+               restfreq=restfreq_str,
+               outframe='lsrk',
+               veltype='radio',
+               # Workflow
+               calcres=self.calcres,
+               calcpsf=self.calcpsf,
+               # Deconvolver
+               deconvolver=self.deconvolver,
+               scales=self.scales_as_pix,
+               smallscalebias=self.smallscalebias,
+               pblimit=self.pblimit,
+               normtype='flatnoise',
+               # Restoring beam
+               restoringbeam=self.restoringbeam,
+               # U-V plane gridding
+               weighting='briggs',
+               robust=self.briggs_weight,
+               uvtaper=uv_taper_string,
+               # Stopping criterion
+               niter=self.niter,
+               threshold=self.threshold,
+               cycleniter=self.cycle_niter,
+               cyclefactor=3.0,
+               minpsffraction=self.minpsffraction,
+               # Mask
+               usemask=self.usemask,
+               mask=self.mask,
+               pbmask=self.pblimit,
+               # UI
+               interactive=self.interactive,
+               )
+
+        if self.logfile != None:
+            casaStuff.casalog.setlogfile(oldlogfile)
+
+#endregion
+
+
+
+
+
+
+    
+def make_dirty_map(
+    clean_call = None, 
+    ):
+    """
+    Create a dirty map from a measurement set.
+    """
+    
+    if type(clean_call) != type(CleanCall()):
+        logger.error("Please input a valid clean call!")
+        raise Exception("Please input a valid clean call!")
+    
+    clean_call.niter = 0
+    clean_call.reset = True
+    clean_call.usemask = 'pb'
+    clean_call.logfile = clean_call.image_root+'_dirty.log'
+    
+    clean_call.calcres = True
+    clean_call.calcpsf = True
+    clean_call.execute()
+    
+    clean_call.reset = False
+    clean_call.usemask = 'pb'
+    clean_call.logfile = None
+    
+    save_copy_of_cube(
+        input_root=clean_call.image_root,
+        output_root=clean_call.image_root+'_dirty')
+
+
+
+
+
+
+
+
+
+
+def clean_loop(
+    clean_call = None,
+    record_file=None,
+    log_ext=None,
+    delta_flux_threshold=0.02,    
+    absolute_delta=True,
+    absolute_threshold=None,
+    snr_threshold=4.0,
+    stop_at_negative=True,
+    remask=False,
+    max_loop = 20
+    ):
+    """
+    Carry out an iterative clean until a convergence criteria is met.
+    """
+
+   # Note the number of channels, which is used in setting the number
+   # of iterations that we give to an individual clean call.
+
+    vm = au.ValueMapping(clean_call.vis)
+    nchan = vm.spwInfo[0]['numChannels']
+
+    # Figure out the number of iterations we will use. Note that this
+    # step is highly tunable, and can still be improved as we go
+    # forward.
+
+    base_niter = 10*nchan
+    base_cycle_niter = 100
+    loop = 1
+
+    # Initialize our tracking of the flux in the model
+
+    model_flux = 0.0
+
+    # Open the text record if desired
+
+    if record_file != None:
+        f = open(record_file,'w')
+        f.write("# column 1: loop type\n")
+        f.write("# column 2: loop number\n")
+        f.write("# column 3: supplied threshold\n")
+        f.write("# column 4: model flux at end of this clean\n")
+        f.write("# column 5: fractional change in flux (current-previous)/current\n")
+        f.write("# column 6: number of iterations allocated (not necessarily used)\n")
+        f.close()
+
+    # Run the main loop
+
+    proceed = True
+    while proceed == True and loop <= max_loop:
+
+        # Figure out how many iterations to give clean.
+
+        if loop > 5:
+            factor = 5
+        else:
+            factor = (loop-1)
+        
+        clean_call.niter = base_niter*(2**factor)
+        clean_call.cycle_niter = base_cycle_niter*factor
+        
+        # Set the threshold for the clean call.
+
+        if snr_threshold != None:
+            resid_stats = stat_clean_cube(clean_call.image_root+'.residual')        
+            current_noise = resid_stats['medabsdevmed'][0]/0.6745
+            clean_call.threshold = str(current_noise*snr_threshold)+'Jy/beam'
+        elif absolute_threshold != None:
+            clean_call.threshold = absolute_threshold
+
+        # If requested mask at each step (this is experimental, we're
+        # seeing if it helps to avoid divergence during the deep
+        # single scale clean.)
+
+        if remask:
+            logger.info("")
+            logger.info("Remasking.")
+            logger.info("")
+            signal_mask(
+                cube_root=clean_call.image_root,
+                out_file=clean_call.image_root+'.mask',
+                operation='AND',
+                high_snr=4.0,
+                low_snr=2.0,
+                absolute=False)
+            clean_call.usemask='user'
+
+        # Set the log file
+
+        if log_ext != None:
+            clean_call.logfile = cube_root+"_loop_"+str(loop)+"_"+log_ext+".log"
+        else:
+            clean_call.logfile = None
+
+        # Save the previous version of the file
+        save_copy_of_cube(
+            input_root=clean_call.image_root,
+            output_root=clean_call.image_root+'_prev')
+
+        # Execute the clean call.
+
+        clean_call.reset = False
+        clean_call.execute()
+
+        clean_call.niter = 0
+        clean_call.cycle_niter = 200
+
+        # Record the new model flux and check for convergence. A nice
+        # way to improve this would be to calculate the flux per
+        # iteration.
+
+        model_stats = stat_clean_cube(clean_call.image_root+'.model')
+
+        prev_flux = model_flux
+        model_flux = model_stats['sum'][0]
+
+        delta_flux = (model_flux-prev_flux)/model_flux
+        if absolute_delta:
+            delta_flux = abs(delta_flux)
+
+        if delta_flux_threshold >= 0.0:
+            proceed = \
+                (delta_flux > delta_flux_threshold)
+
+        if stop_at_negative:
+            if model_flux < 0.0:
+                proceed = False
+            
+        # Print output
+                
+        logger.info("")
+        logger.info("******************************")
+        logger.info("CLEAN LOOP "+str(loop))
+        logger.info("... threshold "+str(clean_call.threshold))
+        logger.info("... old flux "+str(prev_flux))
+        logger.info("... new flux "+str(model_flux))
+        logger.info("... fractional change "+str(delta_flux)+" compare to stopping criterion of "+str(delta_flux_threshold))
+        logger.info("... proceed? "+str(proceed))
+        logger.info("******************************")
+        logger.info("")
+
+        # Record to log
+
+        if record_file != None:
+            line = 'LOOP '+str(loop)+ \
+                ' '+clean_call.threshold+' '+str(model_flux)+ \
+                ' '+str(delta_flux) + ' ' + str(clean_call.niter)+ '\n' 
+            f = open(record_file,'a')
+            f.write(line)
+            f.close()
+
+        if proceed == False:
+            break
+        loop += 1
+
+    return
+
+
+
+def singlescale_loop(
+    clean_call = None,
+    scales_as_angle=[],
+    record_file=None,
+    delta_flux_threshold=0.02,
+    absolute_delta=True,
+    absolute_threshold=None,
+    snr_threshold=4.0,
+    stop_at_negative=True,
+    remask=False,
+    max_loop = 20
+    ):
+    """
+    Carry out an iterative multiscale clean loop.
+    """
+    
+    # Check that we have a vile clean call
+
+    if type(clean_call) != type(CleanCall()):
+        logger.error("Please input a valid clean call!")
+        raise Exception("Please input a valid clean call!")
+        
+    clean_call.deconvolver = 'hogbom'
+    clean_call.calcres = False
+    clean_call.calcpsf = False
+
+    # Call the loop
+
+    clean_loop(
+        clean_call=clean_call,
+        record_file=record_file,
+        delta_flux_threshold=delta_flux_threshold,
+        absolute_delta=absolute_delta,
+        absolute_threshold=absolute_threshold,
+        snr_threshold=snr_threshold,
+        stop_at_negative=stop_at_negative,
+        remask=remask,
+        max_loop = max_loop      
+        )
+
+    # Save a copy
+
+    save_copy_of_cube(
+        input_root=clean_call.image_root,
+        output_root=clean_call.image_root+'_singlescale')
+
+
+
+def multiscale_loop(
+    clean_call = None,
+    record_file=None,
+    delta_flux_threshold=0.02,
+    absolute_delta=True,
+    absolute_threshold=None,
+    snr_threshold=4.0,
+    stop_at_negative=True,
+    max_loop = 20
+    ):
+    """
+    Carry out an iterative multiscale clean loop.
+    """
+    
+    # Check that we have a vile clean call
+
+    if type(clean_call) != type(CleanCall()):
+        logger.error("Please input a valid clean call!")
+        raise Exception("Please input a valid clean call!")
+    
+    # Figure out the scales to use in pixel units
+
+    cell_as_num = float((clean_call.cell_size.split('arcsec'))[0])
+    scales_as_pix = []
+    for scale in clean_call.scales_as_angle:
+        scales_as_pix.append(int(scale/cell_as_num))
+        
+    clean_call.deconvolver = 'multiscale'
+    clean_call.scales_as_pix = scales_as_pix
+    clean_call.calcres = False
+    clean_call.calcpsf = False
+
+    logger.info("I will use the following scales: ")
+    logger.info("... as pixels: " + str(clean_call.scales_as_pix))
+    logger.info("... as arcseconds: " + str(clean_call.scales_as_angle))
+
+    # Call the loop
+
+    clean_loop(
+        clean_call=clean_call,
+        record_file=record_file,
+        delta_flux_threshold=delta_flux_threshold,
+        absolute_delta=absolute_delta,
+        absolute_threshold=absolute_threshold,
+        snr_threshold=snr_threshold,
+        stop_at_negative=stop_at_negative,
+        max_loop = max_loop      
+        )
+
+    # Save a copy
+
+    save_copy_of_cube(
+        input_root=clean_call.image_root,
+        output_root=clean_call.image_root+'_multiscale')
+
+
+
+
+
+
+
+

--- a/phangsPipeline/clean_call.py
+++ b/phangsPipeline/clean_call.py
@@ -1,0 +1,48 @@
+"""
+This is a dummy CleanCall class for dry run only, or to be inheritted by casaImagingRoutines.CleanCall.
+"""
+
+
+
+#region class CleanCall
+
+class CleanCall:
+    
+    def __init__(self):
+        self.vis = None
+        self.antenna = ""
+        self.image_root = None
+        self.phase_center = ""
+        self.image_size = None
+        self.cell_size = None
+        self.restfreq_ghz = -1.0
+        self.calcres = True
+        self.calcpsf = True
+        self.specmode = 'cube'
+        self.deconvolver = 'hogbom'
+        self.threshold = '0.0mJy/beam'
+        self.scales_as_pix = [0]
+        self.scales_as_angle = None
+        self.smallscalebias = 0.9
+        self.briggs_weight = 0.5
+        self.niter = 0
+        self.cycle_niter = 200
+        self.minpsffraction = 0.5
+        self.pblimit = 0.25
+        self.uvtaper = None
+        self.restoringbeam = 'common'
+        self.usemask = 'user'
+        self.mask = ''
+        self.interactive = False
+        self.rest = False
+        self.logfile = None
+        self.clean_mask_file = None
+
+    def execute(self):
+        """
+        Execute the clean call.
+        """
+        pass
+
+#endregion
+

--- a/phangsPipeline/imagingHandler.py
+++ b/phangsPipeline/imagingHandler.py
@@ -1,0 +1,585 @@
+"""imagingHandler
+
+This module makes image cubes out of the uv data from each spectral line and continuum of each galaxy. 
+
+This code needs to be run inside CASA. 
+
+Example:
+    $ casa
+    from phangsPipeline import keyHandler as kh
+    from phangsPipeline import imagingHandler as imh
+    this_kh = kh.KeyHandler(master_key = 'config_keys/master_key.txt')
+    this_imh = uvh.ImagingHandler(key_handler = this_kh)
+    this_imh.set_targets(only = ['ngc3627'])
+    this_imh.loop_imaging()
+    
+"""
+
+#<TODO># 20200210 dzliu: self._kh._cleanmask_dict is always None. It is not yet implemented in "keyHandler.py"!
+#<TODO># 20200214 dzliu: will users want to do imaging for individual project instead of concatenated ms?
+#<TODO># 20200214 dzliu: needing KeyHandler API: 
+#<TODO># 20200214 dzliu:     self._kh._cleanmask_dict   --> self._kh.get_cleanmask() # input target name, output clean mask file
+#<TODO># 20200214 dzliu:     self._kh._target_dict      --> self._kh.get_target_dict() # for rastring, decstring
+#<TODO># 20200214 dzliu:     self._kh._override_dict    --> self._kh.get_overrides()
+#<TODO># 20200214 dzliu:     self._kh._dir_keys         --> self._kh.get_target_name_for_multipart_name()
+#<TODO># 20200214 dzliu:     self._kh._config_dict['interf_config']['clean_scales_arcsec'] # angular scales
+
+import os, sys, re, shutil
+import glob
+import numpy as np
+
+import logging
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+casa_enabled = (sys.argv[0].endswith('start_casa.py'))
+
+if casa_enabled:
+    logger.debug('casa_enabled = True')
+    import casaCubeRoutines as ccr
+    import casaMosaicRoutines as cmr
+    import casaFeatherRoutines as cfr
+    import casaImagingRoutines as imr
+    import casaMaskingRoutines as msr
+    reload(imr) #<TODO><DEBUG># 
+    reload(msr) #<TODO><DEBUG># #<TODO># we still need imr.cleanCall for dry_run?
+    reload(imr) #<TODO><DEBUG># 
+    from imr import CleanCall
+else:
+    logger.debug('casa_enabled = False')
+    sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+    from clean_call import CleanCall
+
+import utils
+import line_list
+import handlerTemplate
+
+
+class ImagingHandler(handlerTemplate.HandlerTemplate):
+    """
+    Class to makes image cubes out of uv data from each spectral line and continuum of each galaxy. 
+    """
+    
+    ############
+    # __init__ #
+    ############
+    
+    def __init__(
+        self, 
+        key_handler = None, 
+        dry_run = False, 
+        ):
+        
+        # inherit template class
+        handlerTemplate.HandlerTemplate.__init__(self,key_handler = key_handler, dry_run = dry_run)
+    
+    
+    
+    ################
+    # loop_imaging #
+    ################
+    
+    def loop_imaging(
+        self, 
+        target = None, 
+        project = None, 
+        config = None, 
+        product = None, 
+        process_individual_mosaic = False, 
+        process_individual_project = False, 
+        do_chan0 = False, 
+        make_dirty_image = True, 
+        revert_to_dirty = False, 
+        read_in_clean_mask = True, 
+        run_multiscale_clean = True, 
+        revert_to_multiscale = False, 
+        make_singlescale_mask = True, 
+        run_singlescale_clean = True, 
+        do_export_to_fits = True, 
+        forceSquare = False, 
+        make_directories = True, 
+        overwrite = False, 
+        dry_run = False, 
+        ): 
+        """This function makes an image cube for each product, each config of each target. 
+        
+        This includes following tasks: 
+            task_clean_call()
+        
+        Args:
+            target (list or str): Galaxy name(s).
+            config (list or str): Configuration(s) like '12m', '7m', '12m+7m'.
+            product (list or str): Product name(s) like 'co21', 'c18o21', 'cont'.
+            
+        """
+        
+        if len(self.get_targets()) == 0:            
+            logger.error("Need a target list.")
+            return(None)
+        
+        if len(self.get_all_products()) == 0:            
+            logger.error("Need a products list.")
+            return(None)
+        
+        if make_directories:
+            self._kh.make_missing_directories(imaging=True)
+        
+        # loop
+        for this_target in self.get_targets():
+            for this_product in self.get_all_products():
+                for this_config in self.get_interf_configs():
+                    # 
+                    # get imaging dir
+                    this_imaging_dir = self._kh.get_imaging_dir_for_target(this_target)
+                    # 
+                    # set project to empty <TODO>
+                    this_project = ''
+                    # 
+                    # print starting message
+                    logger.info("")
+                    logger.info("--------------------------------------------------------")
+                    logger.info("START: Imaging the data set.")
+                    logger.info("--------------------------------------------------------")
+                    logger.info('Target: '+this_target)
+                    logger.info('Config: '+this_config)
+                    logger.info('Product: '+this_product)
+                    logger.info('Imaging dir: '+this_imaging_dir)
+                    # 
+                    # check config suffix if processing individual project ms data
+                    if process_individual_project:
+                        this_config_suffix = re.sub(r'^(.*?)_([0-9]+)$', r'\2', this_config)
+                        this_config = re.sub(r'^(.*?)_([0-9]+)$', r'\1', this_config)
+                    # 
+                    # 
+                    # change directory to imaging dir
+                    current_dir = os.getcwd()
+                    os.chdir(this_imaging_dir)
+                    # 
+                    # 
+                    # build clean call
+                    logger.info('Running recipe_build_clean_call')
+                    clean_call = \
+                    self.recipe_build_clean_call(
+                        target = this_target, 
+                        project = this_project, 
+                        config = this_config, 
+                        product = this_product, 
+                        tag = '', 
+                        forceSquare = forceSquare, 
+                        overwrite = overwrite, 
+                        )
+                    # 
+                    # 
+                    # make imaging recipe
+                    if clean_call is not None:
+                        logger.info('Running recipe_imaging_one_target')
+                        self.recipe_imaging_one_target(
+                            clean_call = clean_call, 
+                            make_dirty_image = make_dirty_image, 
+                            revert_to_dirty = revert_to_dirty, 
+                            read_in_clean_mask = read_in_clean_mask, 
+                            run_multiscale_clean = run_multiscale_clean, 
+                            revert_to_multiscale = revert_to_multiscale, 
+                            make_singlescale_mask = make_singlescale_mask, 
+                            run_singlescale_clean = run_singlescale_clean, 
+                            do_export_to_fits = do_export_to_fits, 
+                            overwrite = overwrite, 
+                            )
+                    # 
+                    # image chan0 <TODO>
+                    #if do_chan0:
+                    #    this_product+'_chan0'
+                    #    raise NotImplementedError()
+                    # 
+                    # 
+                    # change dir back
+                    os.chdir(current_dir)
+                    # 
+                    # 
+                    # print ending message
+                    logger.info("--------------------------------------------------------")
+                    logger.info("END: Imaging the data set.")
+                    logger.info("--------------------------------------------------------")
+                # 
+                # end of for configs
+            # 
+            # end of for line or cont products
+        # 
+        # end of for targets
+    # 
+    # end of loop_imaging()
+    
+    
+    
+    #############################
+    # task_pick_cell_and_imsize #
+    #############################
+    
+    def task_pick_cell_and_imsize(
+        self, 
+        in_file=None,
+        oversamp=5,
+        forceSquare=False
+        ):
+        """Pick a cell size and imsize for cleaning. 
+        
+        This will call casaImagingRoutines.estimate_cell_and_imsize() first, 
+        then apply custom overrides if any.
+        """
+        
+        if (not self._dry_run) and casa_enabled:
+            cell_size_string, x_size_string, y_size_string = \
+                imr.estimate_cell_and_imsize(in_file, 
+                                             oversamp,
+                                             forceSquare=forceSquare)
+        else:
+            cell_size_string, x_size_string, y_size_string = \
+                '0.1', '1000', '1000'
+            logger.info('DRY RUN skips calling imr.estimate_cell_and_imsize()')
+                
+        # Check for overrides
+        #<TODO> should we remove the '.ms' suffix?
+        logger.debug('Checking overrides for "'+in_file+'"')
+        if self._kh.has_overrides_for_key(in_file):
+            cell_size_string = self._kh.get_overrides(key = in_file, param = 'cell_size', default = cell_size_string)
+            x_size_string = self._kh.get_overrides(key = in_file, param = 'x_size', default = x_size_string)
+            y_size_string = self._kh.get_overrides(key = in_file, param = 'y_size', default = y_size_string)
+        return cell_size_string, x_size_string, y_size_string
+    
+    
+    
+    ###########################
+    # recipe_build_clean_call #
+    ###########################
+    
+    def recipe_build_clean_call(
+        self, 
+        target = None, 
+        project = None, 
+        config = None, 
+        product = None, 
+        tag = '', 
+        forceSquare = False, 
+        overwrite = False, 
+        dry_run = False, 
+        ):
+        """Build a clean call before running the clean task with the function phangsImagingRecipe().
+        """
+        
+        # 
+        # This code is adapted from the function buildPhangsCleanCall() in phangsPipeline.py / imagingPipeline.py.
+        # 
+        
+        # 
+        # check user input. 
+        if target is None or config is None or product is None:
+            logger.error('Please input target, config and product! (e.g., target = "ngc3627_1", config = "12m+7m", product = "co21")')
+            raise Exception('Please input target, config and product!')
+        # 
+        # Initialize the call
+        clean_call = CleanCall()
+        # 
+        # Set ms data file name
+        if project is None or project == '':
+            clean_call.vis = target+'_'+config+'_'+product+'.ms'
+        else:
+            clean_call.vis = target+'_'+project+'_'+config+'_'+product+'.ms'
+        # 
+        # append tag
+        if tag == '':
+            clean_call.image_root = target+'_'+config+'_'+product
+        else:
+            clean_call.image_root = target+'_'+config+'_'+product+'_'+tag
+        # 
+        # select antenna
+        if config == '12m+7m':
+            clean_call.antenna = ''
+            #clean_call.antenna = select_12m7m
+        if config == '12m':
+            clean_call.antenna = ''
+            #clean_call.antenna = select_12m
+        if config == '7m':
+            clean_call.antenna = ''
+            #clean_call.antenna = select_7m
+        # 
+        # Look up the center and shape of the mosaic
+        mosaic_key = self._kh._target_dict # read_mosaic_key()
+        this_ra = mosaic_key[target]['rastring']
+        this_dec = mosaic_key[target]['decstring']
+        clean_call.phase_center = 'J2000 '+this_ra+' '+this_dec
+        # 
+        # check ms data file
+        if not os.path.isdir(clean_call.vis):
+            logger.warning("Visibility data "+'"'+os.getcwd()+os.sep+clean_call.vis+'"'+" not found. Returning empty.")
+            return None
+        # 
+        # get cell size and imsize
+        cell_size, x_size, y_size = \
+            self.task_pick_cell_and_imsize(\
+                clean_call.vis, 
+                forceSquare=forceSquare) #<TODO># dzliu: this can be improved
+        image_size = [int(x_size), int(y_size)]
+        
+        clean_call.cell_size = cell_size
+        clean_call.image_size = image_size
+        
+        # Look up the line and data product
+        
+        if product == 'co21':
+            clean_call.specmode = 'cube'
+            clean_call.restfreq_ghz = line_list.line_list['co21']
+
+        if product == 'co21_chan0':
+            clean_call.specmode = 'mfs'
+            clean_call.restfreq_ghz = line_list.line_list['co21']
+
+        if product == 'c18o21':
+            clean_call.specmode = 'cube'
+            clean_call.restfreq_ghz = line_list.line_list['c18o21']
+
+        if product == 'c18o21_chan0':
+            clean_call.specmode = 'mfs'
+            clean_call.restfreq_ghz = line_list.line_list['c18o21']
+
+        if product == 'cont':
+            clean_call.specmode = 'mfs'
+            clean_call.restfreq_ghz = -1.0
+        
+        # Set angular scales to be used in multiscale clean
+        #scales_for_clean = self._config_dict['interf_config'][this_config]['clean_scales_arcsec']
+        
+        if config == '7m':
+            clean_call.pblimit = 0.25
+            clean_call.smallscalebias = 0.6
+            clean_call.scales_as_angle = [0, 5, 10]
+        elif config == '12m':
+            clean_call.smallscalebias = 0.6
+            clean_call.scales_as_angle = [0, 1, 2.5, 5]
+        elif config == '12m+7m':
+            clean_call.smallscalebias = 0.8
+            clean_call.scales_as_angle = [0, 1, 2.5, 5, 10]
+        
+        # Look up overrides in the imaging parameters
+        override_dict = self._kh._override_dict # read_override_imaging_params()
+
+        if clean_call.image_root in override_dict:
+            this_override_dict = override_dict[clean_call.image_root]
+
+            if 'smallscalebias' in this_override_dict:
+                clean_call.smallscalebias = float(this_override_dict['smallscalebias'])
+            if 'x_size' in this_override_dict:
+                clean_call.image_size[0] = int(this_override_dict['x_size'])
+            if 'y_size' in this_override_dict:
+                clean_call.image_size[1] = int(this_override_dict['y_size'])
+            if 'pblimit' in this_override_dict:
+                clean_call.pblimit = float(this_override_dict['pblimit'])
+            if 'scales_as_angle' in this_override_dict:
+                scales_as_angle_string = this_override_dict['scales_as_angle']
+                tokens = scales_as_angle_string.split(',')
+                scales_as_angle = []
+                for token in tokens:
+                    if token == '':
+                        continue
+                    scales_as_angle.append(float(token))
+                clean_call.scales_as_angle = scales_as_angle
+        
+        # Define the clean mask (note one mask per galaxy)
+        
+        dir_key = self._kh._dir_keys # read_dir_key() #<TODO># Need KeyHandler function get_target_name_by_multipart_name()
+        if target in dir_key:
+            this_gal = dir_key[target]
+        else:
+            this_gal = target
+        
+        cleanmask_dict = self._kh._cleanmask_dict
+        if cleanmask_dict is None:
+            cleanmask_dict = {}
+        if this_gal in cleanmask_dict:
+            this_cleanmask = cleanmask_dict[this_gal]
+        else:
+            logger.error('Error! Clean mask is not defined for target "'+this_gal+'" in "cleanmask_key.txt"! cleanmask_dict: '+str(cleanmask_dict.keys()))
+            #raise Exception('Error! Clean mask is not defined for target "'+this_gal+'" in "cleanmask_key.txt"!')
+            #this_cleanmask = '../clean_masks/'+this_gal+'_co21_clean_mask.fits' #<TODO># this needs discussion and improvement
+            this_cleanmask = ''
+            #<TODO># 20200210 dzliu: self._kh._cleanmask_dict is always None. It is not yet implemented in "keyHandler.py"!
+        
+        if os.path.isfile(this_cleanmask):
+            clean_call.clean_mask_file = this_cleanmask
+        else:
+            clean_call.clean_mask_file = None
+            logger.warning('Warning! Clean mask for target "'+this_gal+'" was not found: "'+this_cleanmask+'"')
+        
+        # 
+        # Return
+        return clean_call
+    
+    # end of recipe_build_clean_call()
+    
+    
+    
+    
+    #############################
+    # recipe_imaging_one_target #
+    #############################
+    
+    def recipe_imaging_one_target(
+        self, 
+        clean_call = None, 
+        make_dirty_image = True, 
+        revert_to_dirty = False, 
+        read_in_clean_mask = True, 
+        run_multiscale_clean = True, 
+        revert_to_multiscale = False, 
+        make_singlescale_mask = True, 
+        run_singlescale_clean = True, 
+        do_export_to_fits = True, 
+        overwrite = False, 
+        ): 
+        """PHANGS imaging recipe. 
+        
+        Including steps:
+            Dirty image -> 
+            mask alignment -> 
+            lightly masked multiscale clean -> 
+            heavily masked single scale clean -> 
+            export.
+
+        """
+        
+        # 
+        # This code is adapted from the function phangsImagingRecipe() in phangsPipeline.py / imagingPipeline.py.
+        # 
+        
+        if make_dirty_image:
+            if (not self._dry_run) and casa_enabled:
+                logger.info("")
+                logger.info("MAKING THE DIRTY IMAGE.")
+                logger.info("")
+                imr.make_dirty_map(clean_call)
+            else:
+                logger.info('DRY RUN skips outputting to '+clean_call.image_root+'_dirty'+'.*')
+
+        if revert_to_dirty:
+            if (not self._dry_run) and casa_enabled:
+                logger.info("")
+                logger.info("RESETING THE IMAGING TO THE DIRTY IMAGE.")
+                logger.info("")
+                imr.replace_cube_with_copy(
+                    to_root=clean_call.image_root,
+                    from_root=clean_call.image_root+'_dirty')
+            else:
+                logger.info('DRY RUN skips outputting to '+clean_call.image_root+'.*')
+
+        if read_in_clean_mask:
+            if (not self._dry_run) and casa_enabled:
+                logger.info("")
+                logger.info("READING IN THE CLEAN MASK.")
+                logger.info("")
+                if clean_call.clean_mask_file is not None:
+                    msr.import_and_align_mask(
+                        in_file=clean_call.clean_mask_file,
+                        out_file=clean_call.image_root+'.mask',
+                        template=clean_call.image_root+'.image',
+                        )
+                    clean_call.usemask = 'user'
+                else:
+                    logger.info("No clean mask defined.")
+                    clean_call.usemask = 'pb'
+            else:
+                logger.info("DRY RUN skips setting the clean mask")
+                clean_call.usemask = 'pb'
+        
+        if run_multiscale_clean:
+            if (not self._dry_run) and casa_enabled:
+                logger.info("")
+                logger.info("RUNNING THE MULTISCALE CLEAN.")
+                logger.info("")
+                imr.multiscale_loop(
+                    clean_call = clean_call,
+                    record_file = clean_call.image_root+'_multiscale_record.txt',
+                    delta_flux_threshold=0.01,
+                    absolute_threshold=None,
+                    snr_threshold=4.0,
+                    stop_at_negative=True,
+                    max_loop = 20
+                    )
+            else:
+                logger.info("DRY RUN skips running imr.multiscale_loop() and outputting to "+clean_call.image_root+'_multiscale'+'.*')
+
+        if revert_to_multiscale:
+            if (not self._dry_run) and casa_enabled:
+                logger.info("")
+                logger.info("RESETING THE IMAGING TO THE OUTPUT OF MULTISCALE CLEAN.")
+                logger.info("")
+                imr.replace_cube_with_copy(
+                    to_root=clean_call.image_root,
+                    from_root=clean_call.image_root+'_multiscale')
+            else:
+                logger.info("DRY RUN skips outputting to "+clean_call.image_root+'_multiscale'+'.*')
+
+        if make_singlescale_mask:
+            if (not self._dry_run) and casa_enabled:
+                logger.info("")
+                logger.info("MAKING THE MASK FOR SINGLE SCALE CLEAN.")
+                logger.info("")
+                msr.signal_mask(
+                    cube_root=clean_call.image_root,
+                    out_file=clean_call.image_root+'.mask',
+                    operation='AND',
+                    high_snr=4.0,
+                    low_snr=2.0,
+                    absolute=False)
+                clean_call.usemask='user'
+            else:
+                logger.info("DRY RUN skips running msr.signal_mask() and setting the clean mask")
+            
+        if run_singlescale_clean:
+            if (not self._dry_run) and casa_enabled:
+                logger.info("")
+                logger.info("RUNNING THE SINGLE SCALE CLEAN.")
+                logger.info("")
+                imr.singlescale_loop(
+                    clean_call = clean_call,
+                    record_file = clean_call.image_root+'_singlescale_record.txt',
+                    delta_flux_threshold=0.01,
+                    absolute_delta=True,
+                    absolute_threshold=None,
+                    snr_threshold=1.0,
+                    stop_at_negative=False,
+                    remask=False,
+                    max_loop = 20
+                    )
+            else:
+                logger.info("DRY RUN skips running imr.singlescale_loop() and outputting to "+clean_call.image_root+'_singlescale'+'.*')
+
+        if do_export_to_fits:
+            if (not self._dry_run) and casa_enabled:
+                logger.info("")
+                logger.info("EXPORTING PRODUCTS TO FITS.")
+                logger.info("")
+                imr.export_to_fits(clean_call.image_root)
+                imr.export_to_fits(clean_call.image_root+'_dirty')
+                imr.export_to_fits(clean_call.image_root+'_multiscale')
+            else:
+                logger.info("DRY RUN skips running imr.export_to_fits() and outputting to "+clean_call.image_root+'*.fits')
+        
+        return
+    
+    # end of recipe_imaging_one_target()
+    
+    
+
+
+    
+    
+    
+    
+    
+    
+
+
+
+
+
+
+

--- a/phangsPipeline/keyHandler.py
+++ b/phangsPipeline/keyHandler.py
@@ -1704,18 +1704,55 @@ class KeyHandler:
 
         return()        
 
-    def get_overrides(self, key=None, param=None):
+    def has_overrides_for_key(self, key=None):
+        """Check whether the override dictionary contains the input key or not.
+        
+        The key is usually a file name or a galaxy name.
+        """
+        
+        if self._override_dict is None:
+            return False
+
+        # check key
+        if key is None:
+            return False
+        
+        # check key
+        if key in self._override_dict:
+            return True
+        else:
+            return False
+    
+    def get_overrides(self, key=None, param=None, default=None):
         """
         Check the override dictionary for entries given some key,
         parameter pair.
         """
         
         if self._override_dict is None:
-            return(None)
+            return default
 
-        # TBD
-
-        pass
+        # check key and param
+        if key is None and param is None:
+            logger.error('Please input key and param to get overrides!')
+            raise Exception('Please input key and param to get overrides!')
+            return default
+        
+        # check key in override dict or not
+        if not (key in self._override_dict):
+            logger.warning('Warning! The input key "'+str(key)+'" is not in the overrides file!')
+            return default
+        
+        # if user has input key only, return the dict
+        if param is None:
+            logger.warning('Warning! Only has key input when getting overrides! Will return the override dictionary for this key "'+str(key)+'".')
+            return self._override_dict[key] #<TODO># dzliu: what if user has just input a key?
+        
+        if not (param in self._override_dict[key]):
+            logger.warning('Warning! The input key "'+str(key)+'" is not in the overrides file!')
+            return default
+        
+        return self._override_dict[key][param]
 
 #endregion
     

--- a/test_imagingHandler.py
+++ b/test_imagingHandler.py
@@ -1,0 +1,18 @@
+# Imports
+from phangsPipeline import keyHandler as kh
+from phangsPipeline import imagingHandler as imh
+
+# Instantiate handlers
+this_kh = kh.KeyHandler()
+this_imh = imh.ImagingHandler(key_handler = this_kh, dry_run = True)
+
+# Set which data to process
+this_imh.set_line_products(only=['co21'])
+this_imh.set_no_cont(True)
+this_imh.set_targets(only=['ngc3627_1'])
+
+# Run end-to-end loop
+this_imh.loop_imaging()
+
+# Run each of the steps individually
+


### PR DESCRIPTION
Now "imagingHandler.py" has been mostly implemented, and the related code are updated accordingly (see below). 

The code in "imagingHandler.py" should now be able to replace "image_data.py". The new handlerTemplate has also been use. In fact, this commit is based on @akleroy's latest commit of 32d0f1b5f85e12a53ba5f83ab89618e72b761107. 

The functions in "imagingHandler.py" are based on the functions in previous "image_data.py", but renamed to `task_*` and `recipe_*` style. 

Necessary functions in "casaImagingRoutines.py" are added based on the previous "phangesPipeline.py", to let ImagingHandler work.

A testing script "test_imagingHandler.py" has been created, which has been tested to work, yet without clean masks.

A few functions in "casaMaskingRoutines.py" have also been added or updated, for the implementation of the ImagingHandler.

Two functions in "keyHandler.py", `def has_overrides_for_key` and `def get_overrides`, have been added and updated respectively, for the implementation of the ImagingHandler.

Yet we note that there are some other necessary KeyHandler APIs to be needed, for example:
```
    self._kh._cleanmask_dict   --> self._kh.get_cleanmask() # input target name, output clean mask file
    self._kh._target_dict      --> self._kh.get_target_dict() # for rastring, decstring
    self._kh._override_dict    --> self._kh.get_overrides()
    self._kh._dir_keys         --> self._kh.get_target_name_for_multipart_name()
    self._kh._config_dict['interf_config']['clean_scales_arcsec'] # angular scales
```

A new module "clean_call.py" has been created, which contains almost the same code as the `CleanCall` class inside "casaImagingRoutines.py". This is needed if we want to run the ImagingHandler with `dry_run = True`. I'm not sure if this is the right way to do, so please let me know your comments. 

Best,
Daizhong
