### PR TITLE
Set min/max to avoid NaNs when there are no finite values

### DIFF
--- a/phangsPipeline/scDerivativeRoutines.py
+++ b/phangsPipeline/scDerivativeRoutines.py
@@ -40,8 +40,16 @@ def update_metadata(projection, cube, error=False):
             hdr[key] = cube.header[key]
         except KeyError:
             pass
-    mx = np.nanmax(projection.filled_data[:].value)
-    mn = np.nanmin(projection.filled_data[:].value)
+
+    # Check if the moment map is empty. If so, nanmax and nanmin
+    # will not be finite and writing the header to disc will fail.
+    if not np.isfinite(projection.filled_data[:].value).any():
+        mx = 0.
+        mn = 0.
+    else:
+        mx = np.nanmax(projection.filled_data[:].value)
+        mn = np.nanmin(projection.filled_data[:].value)
+
     hdr['DATAMAX'] = mx
     hdr['DATAMIN'] = mn
     if 'moment_axis' in projection.meta.keys():


### PR DESCRIPTION
NaNs are returned for operations on a completely masked 2D projection which are not valid FITS header values. This adds a check for empty moment maps and sets the min/max to 0 before writing the FITS file.