### PR TITLE
Use relative imports for phangsPipeline modules

### DIFF
--- a/phangsPipeline/calctimeonsource.py
+++ b/phangsPipeline/calctimeonsource.py
@@ -1,9 +1,9 @@
-# Imports
-from phangsPipeline import phangsLogger as pl
-from phangsPipeline import handlerKeys as kh
-
 # Analysis utilities
 import analysisUtils as au
+
+# Imports
+from . import phangsLogger as pl
+from . import handlerKeys as kh
 
 # Set the logging level
 pl.setup_logger(level='DEBUG', logfile=None)

--- a/phangsPipeline/casaCubeRoutines.py
+++ b/phangsPipeline/casaCubeRoutines.py
@@ -7,23 +7,24 @@ but also may be of general utility.
 #region Imports and definitions
 
 import os
+import glob
+import logging
+
 import numpy as np
 import scipy.ndimage as nd
-import pyfits # CASA has pyfits, not astropy
-import glob
-
-import logging
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+import pyfits  # CASA has pyfits, not astropy
 
 # Analysis utilities
 import analysisUtils as au
 
-# CASA stuff
-import casaStuff
-
 # Pipeline versioning
 from pipelineVersion import version
+
+# CASA stuff
+from . import casaStuff
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 #endregion
 

--- a/phangsPipeline/casaFeatherRoutines.py
+++ b/phangsPipeline/casaFeatherRoutines.py
@@ -6,25 +6,26 @@ combination using CASA's feather.
 #region Imports and definitions
 
 import os
-import numpy as np
-import pyfits # CASA has pyfits, not astropy
 import glob
-
 import logging
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+
+import numpy as np
+import pyfits  # CASA has pyfits, not astropy
 
 # Analysis utilities
 import analysisUtils as au
 
-# CASA stuff
-import casaStuff
-
-# Other pipeline stuff
-import casaCubeRoutines as ccr
-
 # Pipeline versionining
 from pipelineVersion import version as pipeVer
+
+# CASA stuff
+from . import casaStuff
+
+# Other pipeline stuff
+from . import casaCubeRoutines as ccr
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 #endregion
 

--- a/phangsPipeline/casaImagingRoutines.py
+++ b/phangsPipeline/casaImagingRoutines.py
@@ -5,26 +5,27 @@ Standalone routines related to CASA imaging.
 #region Imports and definitions
 
 import os
-import numpy as np
-import pyfits # CASA has pyfits, not astropy
 import glob, copy, inspect
-
 import logging
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+
+import numpy as np
+import pyfits  # CASA has pyfits, not astropy
 
 # Analysis utilities
 import analysisUtils as au
 
-# CASA stuff
-import casaStuff
-import casaMaskingRoutines as cmr
-
-# Clean call object
-from clean_call import CleanCall
-
 # Pipeline versionining
 from pipelineVersion import version as pipeVer
+
+# CASA stuff
+from . import casaStuff
+from . import casaMaskingRoutines as cmr
+
+# Clean call object
+from .clean_call import CleanCall
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 #endregion
 

--- a/phangsPipeline/casaMaskingRoutines.py
+++ b/phangsPipeline/casaMaskingRoutines.py
@@ -12,26 +12,25 @@ mask manipulation steps in CASA.
 # region Imports and definitions
 
 import os
-import numpy as np
-from scipy.special import erfc
-import scipy.ndimage as ndimage
-import pyfits  # CASA has pyfits, not astropy
 import glob
-
 import logging
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+import numpy as np
+import scipy.ndimage as ndimage
+from scipy.special import erfc
+import pyfits  # CASA has pyfits, not astropy
 
 # Analysis utilities
 import analysisUtils as au
 
-# CASA stuff
-import casaStuff
-
 # Pipeline versionining
 from pipelineVersion import version as pipeVer
 
+# CASA stuff
+from . import casaStuff
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 # endregion
 

--- a/phangsPipeline/casaMosaicRoutines.py
+++ b/phangsPipeline/casaMosaicRoutines.py
@@ -6,25 +6,26 @@ in CASA.
 #region Imports and definitions
 
 import os
+import glob
+import logging
+
 import numpy as np
 import pyfits # CASA has pyfits, not astropy
-import glob
-
-import logging
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
 
 # Analysis utilities
 import analysisUtils as au
 
-# CASA stuff
-import casaStuff
-
-# Other pipeline stuff
-import casaMaskingRoutines as cma
-
 # Pipeline versionining
 from pipelineVersion import version as pipeVer
+
+# CASA stuff
+from . import casaStuff
+
+# Other pipeline stuff
+from . import casaMaskingRoutines as cma
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 #endregion
 

--- a/phangsPipeline/casaRoutineTests.py
+++ b/phangsPipeline/casaRoutineTests.py
@@ -9,29 +9,30 @@ directory.
 #region Imports and definitions
 
 import os
+import glob
+import logging
+
 import numpy as np
 from scipy.special import erfc
 import pyfits # CASA has pyfits, not astropy
-import glob
-
-import logging
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
 
 # Analysis utilities
 import analysisUtils as au
 
-# CASA stuff
-import casaStuff
-
 # Pipeline versionining
 from pipelineVersion import version as pipeVer
 
+# CASA stuff
+from . import casaStuff
+
 # Pipeline CASA routines
-import casaCubeRoutines as ccr
-import casaMaskingRoutines as cma
-import casaMosaicRoutines as cmr
-import casaFeatherRoutines as cfr
+from . import casaCubeRoutines as ccr
+from . import casaMaskingRoutines as cma
+from . import casaMosaicRoutines as cmr
+from . import casaFeatherRoutines as cfr
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 #endregion
 

--- a/phangsPipeline/casaVisRoutines.py
+++ b/phangsPipeline/casaVisRoutines.py
@@ -7,26 +7,27 @@ Standalone routines to analyze and manipulate visibilities.
 #region Imports and definitions
 
 import os, sys, re, shutil, inspect, copy
+import glob
+import logging
+
 import numpy as np
 from scipy.ndimage import label
-#import pyfits # CASA has pyfits, not astropy
-import glob
-
-import logging
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+#import pyfits  # CASA has pyfits, not astropy
 
 # Analysis utilities
 import analysisUtils as au
 
-# CASA stuff
-import casaStuff
-
-# Spectral lines
-import utilsLines as lines
-
 # Pipeline versionining
 from pipelineVersion import version as pipeVer
+
+# CASA stuff
+from . import casaStuff
+
+# Spectral lines
+from . import utilsLines as lines
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 #endregion
 

--- a/phangsPipeline/handlerDerived.py
+++ b/phangsPipeline/handlerDerived.py
@@ -22,14 +22,15 @@ Example:
 
 import os, sys, re, shutil
 import glob
+import logging
+
 import numpy as np
+import astropy.units as u
 from astropy.io import fits
 from astropy.wcs import WCS
-import astropy.units as u
 from spectral_cube import SpectralCube, Projection
 from spectral_cube.masks import BooleanArrayMask
 
-import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
@@ -47,17 +48,17 @@ else:
     sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 # import phangs pipeline stuff
-import utilsResolutions
-import utilsFilenames
-import utilsLines
-import handlerTemplate
+from . import utilsResolutions
+from . import utilsFilenames
+from . import utilsLines
+from . import handlerTemplate
 
-from scConvolution import smooth_cube
-from scNoiseRoutines import recipe_phangs_noise
-from scMaskingRoutines import recipe_phangs_strict_mask, recipe_phangs_broad_mask
+from .scConvolution import smooth_cube
+from .scNoiseRoutines import recipe_phangs_noise
+from .scMaskingRoutines import recipe_phangs_strict_mask, recipe_phangs_broad_mask
 
-#import scDerivativeRoutines as scderiv
-from scMoments import moment_generator
+#from . import scDerivativeRoutines as scderiv
+from .scMoments import moment_generator
 
 class DerivedHandler(handlerTemplate.HandlerTemplate):
     """

--- a/phangsPipeline/handlerImaging.py
+++ b/phangsPipeline/handlerImaging.py
@@ -52,9 +52,10 @@ Notes:
 
 import os, sys, re, shutil
 import glob
+import logging
+
 import numpy as np
 
-import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
@@ -67,19 +68,19 @@ except ImportError:
 
 if casa_enabled:
     logger.debug('casa_enabled = True')
-    import casaImagingRoutines as imr
-    import casaMaskingRoutines as msr
+    from . import casaImagingRoutines as imr
+    from . import casaMaskingRoutines as msr
     reload(imr)
     reload(msr)
 else:
     logger.debug('casa_enabled = False')
     sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-from clean_call import CleanCall, CleanCallFunctionDecorator
+from .clean_call import CleanCall, CleanCallFunctionDecorator
 
-import utilsLines as lines
-import handlerTemplate
-import utilsFilenames
+from . import utilsLines as lines
+from . import handlerTemplate
+from . import utilsFilenames
 
 class ImagingHandler(handlerTemplate.HandlerTemplate):
     """

--- a/phangsPipeline/handlerKeys.py
+++ b/phangsPipeline/handlerKeys.py
@@ -5,37 +5,19 @@ structure, etc. This part is pure python.
 """
 
 import os, sys, re
-import glob
 import ast
-import numpy as np
+import glob
+import logging
 from math import floor
 
-try:
-    import utilsLines as ll
-except ImportError:
-    from phangsPipeline import utilsLines as ll
+import numpy as np
 
-try:
-    import utilsLists as list_utils
-except ImportError:
-    from phangsPipeline import utilsLists as list_utils
+from . import utilsLines as ll
+from . import utilsLists as list_utils
+from . import utilsKeyReaders as key_readers
+from . import utilsFilenames as fnames
+from . import utilsResolutions
 
-try:
-    import utilsKeyReaders as key_readers
-except ImportError:
-    from phangsPipeline import utilsKeyReaders as key_readers
-
-try:
-    import utilsFilenames as fnames
-except ImportError:
-    from phangsPipeline import utilsFilenames as fnames
-
-try:
-    import utilsResolutions
-except ImportError:
-    from phangsPipeline import utilsResolutions
-
-import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 

--- a/phangsPipeline/handlerPostprocess.py
+++ b/phangsPipeline/handlerPostprocess.py
@@ -14,9 +14,10 @@ calls to CASA from this class.
 
 import os, sys, re, shutil
 import glob
+import logging
+
 import numpy as np
 
-import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
@@ -30,9 +31,9 @@ except ImportError:
 
 if casa_enabled:
     logger.debug('casa_enabled = True')
-    import casaCubeRoutines as ccr
-    import casaMosaicRoutines as cmr
-    import casaFeatherRoutines as cfr
+    from . import casaCubeRoutines as ccr
+    from . import casaMosaicRoutines as cmr
+    from . import casaFeatherRoutines as cfr
     reload(ccr)
     reload(cmr)
     reload(cfr)
@@ -40,9 +41,9 @@ else:
     logger.debug('casa_enabled = False')
     sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-import handlerTemplate
-import utilsFilenames
-import utilsResolutions
+from . import handlerTemplate
+from . import utilsFilenames
+from . import utilsResolutions
 
 class PostProcessHandler(handlerTemplate.HandlerTemplate):
     """

--- a/phangsPipeline/handlerRelease.py
+++ b/phangsPipeline/handlerRelease.py
@@ -19,9 +19,10 @@ Example:
 
 import os, sys, re, shutil
 import glob
+import logging
+
 import numpy as np
 
-import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
@@ -38,11 +39,11 @@ else:
     logger.debug('casa_enabled = False')
     sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-import utils
-import utilsResolutions
-import utilsFilenames
-import utilsLines
-import handlerTemplate
+from . import utils
+from . import utilsResolutions
+from . import utilsFilenames
+from . import utilsLines
+from . import handlerTemplate
 
 
 class ReleaseHandler(handlerTemplate.HandlerTemplate):

--- a/phangsPipeline/handlerVis.py
+++ b/phangsPipeline/handlerVis.py
@@ -27,9 +27,10 @@ Example:
 
 import os, sys, re, shutil
 import glob
+import logging
+
 import numpy as np
 
-import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
@@ -42,21 +43,17 @@ except ImportError:
 
 if casa_enabled:
     logger.debug('casa_enabled = True')
-    import casaVisRoutines as cvr
+    from . import casaVisRoutines as cvr
     reload(cvr) #<TODO><DEBUG>#
 else:
     logger.debug('casa_enabled = False')
     sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-import handlerTemplate
-
-try:
-    import utilsFilenames as fnames
-except ImportError:
-    from phangsPipeline import utilsFilenames as fnames
+from . import handlerTemplate
+from . import utilsFilenames as fnames
 
 # Spectral lines
-import utilsLines as lines
+from . import utilsLines as lines
 
 class VisHandler(handlerTemplate.HandlerTemplate):
     """

--- a/phangsPipeline/scConvolution.py
+++ b/phangsPipeline/scConvolution.py
@@ -1,16 +1,15 @@
-from spectral_cube import SpectralCube, LazyMask
-from radio_beam import Beam
+import logging
 
+import numpy as np
 import astropy.units as u
 from astropy.io import fits
 from astropy.convolution import Box1DKernel
 from astropy.convolution import convolve, convolve_fft
+from radio_beam import Beam
+from spectral_cube import SpectralCube, LazyMask
 
-import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
-
-import numpy as np
 
 def coverage_collapser(coveragecube,
                        coverage2dfile=None,

--- a/phangsPipeline/scDerivativeRoutines.py
+++ b/phangsPipeline/scDerivativeRoutines.py
@@ -1,11 +1,13 @@
-from spectral_cube import SpectralCube, Projection
-import astropy.units as u
-import numpy as np
-from astropy.io import fits
 import inspect
+import logging
+
+import numpy as np
+import astropy.units as u
+from astropy.io import fits
+from spectral_cube import SpectralCube, Projection
+
 from pipelineVersion import version, tableversion
 
-import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 

--- a/phangsPipeline/scMaskingRoutines.py
+++ b/phangsPipeline/scMaskingRoutines.py
@@ -1,20 +1,21 @@
 import logging
+from functools import reduce
+
+import numpy as np
 import scipy.ndimage.morphology as morph
 import scipy.ndimage as nd
-from scipy.signal import savgol_coeffs
-import numpy as np
-from astropy.stats import mad_std
-from astropy.convolution import convolve, Gaussian2DKernel
 import scipy.stats as ss
-
-from spectral_cube import SpectralCube
+from scipy.signal import savgol_coeffs
 import astropy.wcs as wcs
 import astropy.units as u
-from pipelineVersion import version, tableversion
+from astropy.stats import mad_std
+from astropy.convolution import convolve, Gaussian2DKernel
 from astropy.io import fits
+from spectral_cube import SpectralCube
 
-from scNoiseRoutines import mad_zero_centered
-from functools import reduce
+from pipelineVersion import version, tableversion
+from .scNoiseRoutines import mad_zero_centered
+
 np.seterr(divide='ignore', invalid='ignore')
 
 mad_to_std_fac = 1.482602218505602

--- a/phangsPipeline/scMoments.py
+++ b/phangsPipeline/scMoments.py
@@ -1,9 +1,12 @@
-import scDerivativeRoutines as scdr
-from spectral_cube import SpectralCube
-import astropy.units as u
-import numpy as np
 import inspect
 import warnings
+
+import numpy as np
+import astropy.units as u
+from spectral_cube import SpectralCube
+
+from . import scDerivativeRoutines as scdr
+
 warnings.filterwarnings("ignore")
 
 def _nicestr(quantity):

--- a/phangsPipeline/scMoments.py
+++ b/phangsPipeline/scMoments.py
@@ -1,4 +1,5 @@
 import inspect
+import logging
 import warnings
 
 import numpy as np

--- a/phangsPipeline/scNoiseRoutines.py
+++ b/phangsPipeline/scNoiseRoutines.py
@@ -1,17 +1,18 @@
 import logging
-import scipy.ndimage as nd
-from scipy.signal import savgol_coeffs
-import numpy as np
-from astropy.convolution import convolve, Gaussian2DKernel
-import scipy.stats as ss
-from spectral_cube import SpectralCube
-from pipelineVersion import version, tableversion
 
+import numpy as np
+import scipy.ndimage as nd
+import scipy.ndimage.morphology as morph
+import scipy.stats as ss
+from scipy.signal import savgol_coeffs
 import astropy.wcs as wcs
 import astropy.units as u
+from astropy.convolution import convolve, Gaussian2DKernel
 from astropy.io import fits
 from astropy.stats import mad_std
-import scipy.ndimage.morphology as morph
+from spectral_cube import SpectralCube
+
+from pipelineVersion import version, tableversion
 
 np.seterr(divide='ignore', invalid='ignore')
 

--- a/phangsPipeline/scStackingRoutines.py
+++ b/phangsPipeline/scStackingRoutines.py
@@ -1,8 +1,8 @@
 import numpy as np
 import scipy.ndimage as nd
 import astropy.units as u
-from spectral_cube import SpectralCube
 import astropy.wcs as wcs
+from spectral_cube import SpectralCube
 
 def channelShiftVec(x, ChanShift):
     # Shift an array of spectra (x) by a set number of Channels (array)

--- a/phangsPipeline/utilsLines.py
+++ b/phangsPipeline/utilsLines.py
@@ -1,11 +1,14 @@
 # This is the line list.
 
 import re
-import numpy as np
 import logging
+
+import numpy as np
+
+import .utilsLists as lists
+
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
-import phangsPipeline.utilsLists as lists
 
 # Drawn from Splatalogue at http://www.cv.nrao.edu/php/splat/
 


### PR DESCRIPTION
This allows one to import a module/function from outside the phangsPipeline directory without throwing an error. 

Also, I have moved the import calls around so that their ordering follows (roughly) the PEP 8 style.