### PR TITLE
avoid syntax error on load

### DIFF
--- a/phangsPipeline/utilsLines.py
+++ b/phangsPipeline/utilsLines.py
@@ -5,7 +5,7 @@ import logging
 
 import numpy as np
 
-import .utilsLists as lists
+import phangsPipeline.utilsLists as lists
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/phangsPipeline/utilsLines.py
+++ b/phangsPipeline/utilsLines.py
@@ -5,7 +5,7 @@ import logging
 
 import numpy as np
 
-import phangsPipeline.utilsLists as lists
+from . import utilsLists as lists
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
HI @astrojysun -- I reverted a change here that was causing syntax errors on CASA 5.6.1 with the relative imports.  This seems to be related to how we initialize path in the run files (i.e., which I used sys.path.append), but I'm unclear on what's causing it.  Is there a better way to approach this in the run files or a more global fix (e.g., with the `__init__.py` file?

cc: @tonywong94 