### PR TITLE
Fixing big image putchunk/getchunk/putregion memory issue, adding a smart pipelineLogger

### DIFF
--- a/phangsPipeline/__init__.py
+++ b/phangsPipeline/__init__.py
@@ -12,7 +12,6 @@ casa_enabled = is_casa_installed()
 from .phangsLogger import setup_logger
 from .handlerKeys import KeyHandler
 from .handlerSingleDish import SingleDishHandler
-from .handlerAlmaDownload import AlmaDownloadHandler
 from .handlerVis import VisHandler
 from .handlerPostprocess import PostProcessHandler
 from .handlerDerived import DerivedHandler
@@ -24,3 +23,9 @@ __all__ = ["setup_logger", "KeyHandler", "SingleDishHandler", "VisHandler", "Pos
 
 if casa_enabled:
     __all__.append("ImagingHandler")
+
+try:
+    from .handlerAlmaDownload import AlmaDownloadHandler
+    __all__.append("AlmaDownloadHandler")
+except:
+    pass

--- a/phangsPipeline/casaCubeRoutines.py
+++ b/phangsPipeline/casaCubeRoutines.py
@@ -208,8 +208,8 @@ def get_mask(infile, huge_cube_workaround=True):
     
     myia.open(infile)
     
-    has_memory_issue, mask = check_getchunk_putchunk_memory_issue(
-        infile, myia=myia, return_mask=True, 
+    has_memory_issue, mask, cube_shape = check_getchunk_putchunk_memory_issue(
+        infile, myia=myia, return_mask=True, return_shape=True, 
         huge_cube_workaround=huge_cube_workaround)
     
     if has_memory_issue: # getchunk was unsuccessful, has memory issue
@@ -366,8 +366,8 @@ def multiply_cube_by_value(infile, value, brightness_unit, huge_cube_workaround=
     
     myia.open(infile)
     
-    has_memory_issue, vals = check_getchunk_putchunk_memory_issue(
-        infile, myia=myia, return_data=True, 
+    has_memory_issue, vals, cube_shape = check_getchunk_putchunk_memory_issue(
+        infile, myia=myia, return_data=True, return_shape=True, 
         huge_cube_workaround=huge_cube_workaround)
     
     if not has_memory_issue: # getchunk was successful, no memory issue

--- a/phangsPipeline/casaCubeRoutines.py
+++ b/phangsPipeline/casaCubeRoutines.py
@@ -57,7 +57,7 @@ def check_getchunk_putchunk_memory_issue(
     from the input data cube.
     
     This memory issue is also noted in https://casa.nrao.edu/docs/casaref/image.putchunk.html 
-    as: "If all the pixels didn’t easily fit in memory, you would iterate through the image 
+    as: "If all the pixels didn't easily fit in memory, you would iterate through the image 
     chunk by chunk to avoid exhausting virtual memory."
     
     Args:

--- a/phangsPipeline/casaCubeRoutines.py
+++ b/phangsPipeline/casaCubeRoutines.py
@@ -364,10 +364,10 @@ def multiply_cube_by_value(infile, value, brightness_unit, huge_cube_workaround=
     
     myia = au.createCasaTool(casaStuff.iatool)
     
-    myia.open(outfile)
+    myia.open(infile)
     
     has_memory_issue, vals = check_getchunk_putchunk_memory_issue(
-        outfile, myia=myia, return_data=True, 
+        infile, myia=myia, return_data=True, 
         huge_cube_workaround=huge_cube_workaround)
     
     if not has_memory_issue: # getchunk was successful, no memory issue

--- a/phangsPipeline/casaCubeRoutines.py
+++ b/phangsPipeline/casaCubeRoutines.py
@@ -27,11 +27,11 @@ from .pipelineVersion import version as pipeVer
 from . import casaStuff
 
 # Logging
-from .pipelineLogger import PipelineLogger
-logger = PipelineLogger(__name__)
+#from .pipelineLogger import PipelineLogger
+#logger = PipelineLogger(__name__)
 
-#logger = logging.getLogger(__name__)
-#logger.setLevel(logging.DEBUG)
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 #endregion
 

--- a/phangsPipeline/casaCubeRoutines.py
+++ b/phangsPipeline/casaCubeRoutines.py
@@ -215,7 +215,7 @@ def get_mask(infile, huge_cube_workaround=True):
     if has_memory_issue: # getchunk was unsuccessful, has memory issue
         # putchunk channel by channel
         logger.debug('getchunk channel by channel for known memory issue')
-        mask = np.full(cube_shape, fill_value=False)
+        mask = np.full(cube_shape, fill_value=False, dtype=bool)
         if len(cube_shape) == 2:
             blc = [0, 0] # [X, Y]
             trc = [-1, -1] # [X, Y]

--- a/phangsPipeline/casaFeatherRoutines.py
+++ b/phangsPipeline/casaFeatherRoutines.py
@@ -27,6 +27,10 @@ from . import casaStuff
 # Other pipeline stuff
 from . import casaCubeRoutines as ccr
 
+# Logging
+#from .pipelineLogger import PipelineLogger
+#logger = PipelineLogger(__name__)
+
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 

--- a/phangsPipeline/casaFeatherRoutines.py
+++ b/phangsPipeline/casaFeatherRoutines.py
@@ -272,7 +272,7 @@ def feather_two_cubes(
         myia = au.createCasaTool(casaStuff.iatool)
 
         # As noted in [https://casa.nrao.edu/docs/casaref/image.putchunk.html], 
-        # "If all the pixels didn’t easily fit in memory, you would iterate through 
+        # "If all the pixels didn't easily fit in memory, you would iterate through 
         # the image chunk by chunk to avoid exhausting virtual memory."
         # So here we do this iteration if the image cube is too large, 
         # say [3600, 3600,  393] (but [2880, 2880, 393] is okay). 

--- a/phangsPipeline/casaFeatherRoutines.py
+++ b/phangsPipeline/casaFeatherRoutines.py
@@ -288,15 +288,17 @@ def feather_two_cubes(
         no_memory_issue = True
         interf_mask = None
         sd_mask = None
-        if np.prod(interf_shape) >= 3000*3000*393: # known memory issue
+        if np.prod(interf_shape) >= 2880*2880*393: # known memory issue
             no_memory_issue = False
-        if no_memory_issue: 
+        if no_memory_issue: # try to see if there is a memory issue for reading 'interf_file'
+            # in which case the getchunk will return a flat array instead of the cube shape
             myia.open(interf_file)
             interf_mask = myia.getchunk(getmask=True)
             myia.close()
             if not np.all(interf_mask.shape == interf_shape): # shape does not match, has memory issue
                 no_memory_issue = False
-        if no_memory_issue: 
+        if no_memory_issue: # try to see if there is a memory issue for reading 'sd_file'
+            # in which case the getchunk will return a flat array instead of the cube shape
             myia.open(sd_file)
             sd_mask = myia.getchunk(getmask=True)
             myia.close()

--- a/phangsPipeline/casaFeatherRoutines.py
+++ b/phangsPipeline/casaFeatherRoutines.py
@@ -339,37 +339,69 @@ def feather_two_cubes(
         
         else:
             
-            assert len(interf_shape) >= 3
-            nchan = interf_shape[2]
-
-            for ichan in range(nchan):
-                
-                blc = [0, 0, ichan] # [X, Y, CHANNEL]
-                trc = [-1, -1, ichan] # [X, Y, CHANNEL]
-                myia.open(current_interf_file)
-                interf_data_per_chan = myia.getchunk(blc, trc)
-                interf_mask_per_chan = myia.getchunk(blc, trc, getmask=True)
-                myia.close()
-                myia.open(current_sd_file)
-                sd_data_per_chan = myia.getchunk(blc, trc)
-                sd_mask_per_chan = myia.getchunk(blc, trc, getmask=True)
-                myia.close()
-
-                combined_mask_per_chan = interf_mask_per_chan * sd_mask_per_chan
-
-                # CASA calls unmasked values True and masked values False. The
-                # region with values in both cubes is the product.
-                
-                boolean_mask_per_chan = (combined_mask_per_chan == False)
-                if np.any(boolean_mask_per_chan):
-                    interf_data_per_chan[boolean_mask_per_chan] = 0.0
-                    sd_data_per_chan[boolean_mask_per_chan] = 0.0
+            assert len(interf_shape) in [3, 4]
+            
+            if len(interf_shape) == 3:
+                nchan = interf_shape[2]
+                for ichan in range(nchan):
+                    blc = [0, 0, ichan] # [X, Y, CHANNEL]
+                    trc = [-1, -1, ichan] # [X, Y, CHANNEL]
                     myia.open(current_interf_file)
-                    myia.putchunk(interf_data_per_chan, blc)
+                    interf_data_per_chan = myia.getchunk(blc, trc)
+                    interf_mask_per_chan = myia.getchunk(blc, trc, getmask=True)
                     myia.close()
                     myia.open(current_sd_file)
-                    myia.putchunk(sd_data_per_chan, blc)
+                    sd_data_per_chan = myia.getchunk(blc, trc)
+                    sd_mask_per_chan = myia.getchunk(blc, trc, getmask=True)
                     myia.close()
+
+                    combined_mask_per_chan = interf_mask_per_chan * sd_mask_per_chan
+
+                    # CASA calls unmasked values True and masked values False. The
+                    # region with values in both cubes is the product.
+                    
+                    boolean_mask_per_chan = (combined_mask_per_chan == False)
+                    if np.any(boolean_mask_per_chan):
+                        interf_data_per_chan[boolean_mask_per_chan] = 0.0
+                        sd_data_per_chan[boolean_mask_per_chan] = 0.0
+                        myia.open(current_interf_file)
+                        myia.putchunk(interf_data_per_chan, blc)
+                        myia.close()
+                        myia.open(current_sd_file)
+                        myia.putchunk(sd_data_per_chan, blc)
+                        myia.close()
+            
+            elif len(interf_shape) == 4:
+                nchan = interf_shape[2]
+                nstokes = interf_shape[3] # It's okay if Spectral and Stokes axes are swapped.
+                for istokes in range(nstokes):
+                    for ichan in range(nchan):
+                        blc = [0, 0, ichan, istokes] # [X, Y, CHANNEL]
+                        trc = [-1, -1, ichan, istokes] # [X, Y, CHANNEL]
+                        myia.open(current_interf_file)
+                        interf_data_per_chan = myia.getchunk(blc, trc)
+                        interf_mask_per_chan = myia.getchunk(blc, trc, getmask=True)
+                        myia.close()
+                        myia.open(current_sd_file)
+                        sd_data_per_chan = myia.getchunk(blc, trc)
+                        sd_mask_per_chan = myia.getchunk(blc, trc, getmask=True)
+                        myia.close()
+
+                        combined_mask_per_chan = interf_mask_per_chan * sd_mask_per_chan
+
+                        # CASA calls unmasked values True and masked values False. The
+                        # region with values in both cubes is the product.
+                        
+                        boolean_mask_per_chan = (combined_mask_per_chan == False)
+                        if np.any(boolean_mask_per_chan):
+                            interf_data_per_chan[boolean_mask_per_chan] = 0.0
+                            sd_data_per_chan[boolean_mask_per_chan] = 0.0
+                            myia.open(current_interf_file)
+                            myia.putchunk(interf_data_per_chan, blc)
+                            myia.close()
+                            myia.open(current_sd_file)
+                            myia.putchunk(sd_data_per_chan, blc)
+                            myia.close()
 
     else:
         

--- a/phangsPipeline/casaImagingRoutines.py
+++ b/phangsPipeline/casaImagingRoutines.py
@@ -343,10 +343,10 @@ def execute_clean_call(
     # the list of expected_kwargs and only return keys inside it.
     if imaging_method == 'tclean':
         logger.debug("Running CASA " + str(clean_call))
-        expected_kwargs = inspect.getargspec(casaStuff.tclean)[0]
+        expected_kwargs = inspect.getfullargspec(casaStuff.tclean)[0]
     elif imaging_method == 'sdintimaging':
         logger.debug("Running CASA " + str(clean_call).replace('tclean', 'sdintimaging'))
-        expected_kwargs = inspect.getargspec(casaStuff.sdintimaging)[0]
+        expected_kwargs = inspect.getfullargspec(casaStuff.sdintimaging)[0]
     else:
         logger.error('Unexpected imaging method %s' % imaging_method)
         raise Exception('Unexpected imaging method %s' % imaging_method)
@@ -355,6 +355,8 @@ def execute_clean_call(
     active_kwargs = {}  # kwarg dict
 
     if expected_kwargs is not None:
+        if 'self' in expected_kwargs:
+            expected_kwargs.remove('self')
         missing_kwargs = []  # list
         unused_kwargs = []  # list
         for k in expected_kwargs:

--- a/phangsPipeline/casaSingleDishRoutines.py
+++ b/phangsPipeline/casaSingleDishRoutines.py
@@ -361,19 +361,19 @@ def read_spw(filename,source):
     spws_scie = [int(i) for i in spws_scie]
 
     # Read number of channels, frequency at channel zero and compute representative frequency
-    freq_zero_scie  = range(len(spws_scie))
-    chan_width_scie = range(len(spws_scie))
-    num_chan_scie   = range(len(spws_scie))
-    freq_rep_scie   = range(len(spws_scie))
+    freq_zero_scie  = list(range(len(spws_scie)))
+    chan_width_scie = list(range(len(spws_scie)))
+    num_chan_scie   = list(range(len(spws_scie)))
+    freq_rep_scie   = list(range(len(spws_scie)))
     for i in range(len(spws_scie)):
         freq_zero_scie[i]  = float(mytb.getcol('REF_FREQUENCY',startrow=spws_scie[i],nrow=1))
         chan_width_scie[i] = float(mytb.getcol('CHAN_WIDTH',startrow=spws_scie[i],nrow=1)[0])
         num_chan_scie[i]   = float(mytb.getcol('NUM_CHAN',startrow=spws_scie[i],nrow=1))
         freq_rep_scie[i]   = (num_chan_scie[i]/2*chan_width_scie[i]+freq_zero_scie[i])/1e6
-    freq_zero_tsys  = range(len(spws_tsys))
-    chan_width_tsys = range(len(spws_tsys))
-    num_chan_tsys   = range(len(spws_tsys))
-    freq_rep_tsys   = range(len(spws_tsys))
+    freq_zero_tsys  = list(range(len(spws_tsys)))
+    chan_width_tsys = list(range(len(spws_tsys)))
+    num_chan_tsys   = list(range(len(spws_tsys)))
+    freq_rep_tsys   = list(range(len(spws_tsys)))
     for i in range(len(spws_tsys)):
         freq_zero_tsys[i]  = float(mytb.getcol('REF_FREQUENCY',startrow=spws_tsys[i],nrow=1))
         chan_width_tsys[i] = float(mytb.getcol('CHAN_WIDTH',startrow=spws_tsys[i],nrow=1)[0])
@@ -570,7 +570,7 @@ def str_spw4baseline(filename_in,freq_rest,vel_line,spw_line,coords):
     date = (date.split()[0]).replace('-','/')+'/'+date.split()[1]
     vel_line_s = vel_line.split(';')
     nlines = len(vel_line_s)
-    channels_v = range(nlines*2)
+    channels_v = list(range(nlines*2))
     for i in range(nlines):
         vel_str = vel_line_s[i]
         chan1_line,chan2_line,nchan_line,spw_line = convert_vel2chan_line(filename_in,freq_rest,vel_str,spw_line,coords,date)

--- a/phangsPipeline/casaSingleDishRoutines.py
+++ b/phangsPipeline/casaSingleDishRoutines.py
@@ -977,7 +977,8 @@ def gen_tsys_and_flag(filename, spws_info, pipeline, flag_dir='', flag_file='', 
     logger.info("2.3 Initial flagging, reading flags in file file_flags.py. You can modify this file to add more flags")
     extract_flagging(filename, pipeline, flag_dir=flag_dir, flag_file=flag_file)    # Extract flags from original ALMA calibration script (sdflag entries)
     if os.path.exists(path_script+'file_flags.py'): 
-        execfile(path_script+'file_flags.py')    #<TODO><DZLIU># 
+        #execfile(path_script+'file_flags.py')
+        exec(compile(open(path_script+'file_flags.py').read(), path_script+'file_flags.py', 'exec'), globals(), locals())
     
     # 2.4 Create Tsys map 
     logger.info("2.4 Creating Tsysmaps" )

--- a/phangsPipeline/casaStuff.py
+++ b/phangsPipeline/casaStuff.py
@@ -41,7 +41,7 @@ except (ImportError, ModuleNotFoundError):
     # This is for CASA6
 
     import casatools
-    from casatools import (table, image, imager, msmetadata, synthesisimager, synthesisutils)
+    from casatools import (table, image, imager, msmetadata, synthesisimager, synthesisutils, regionmanager)
 
     import casatasks
     from casatasks import (casalog,
@@ -74,6 +74,7 @@ except (ImportError, ModuleNotFoundError):
     # Rename some things for compatibility
 
     iatool = image
+    rgtool = regionmanager
     imtool = imager
     msmdtool = msmetadata
     tbtool = table

--- a/phangsPipeline/casaStuff.py
+++ b/phangsPipeline/casaStuff.py
@@ -27,13 +27,33 @@ try:
     from uvcontsub import uvcontsub
     from visstat import visstat
 
-    # Version
+    # version tuple
 
-    simple_version = '.'.join((casa['version'].split('.'))[0:2])
+    casa_version = tuple(map(int, casa['build']['version'].replace('-','.').split('.')[0:3])) # tested CASA 4, 5
+    
+    # singledish processing imports
+    
+    if casa_version < (5, 0): # for singledish processing with precasa5
+        from sdsave import sdsave
+        from sdlist import sdlist
+        from sdcal2 import sdcal2
+        from sdscale import sdscale
+        from sdplot import sdplot
 
+    from plotms import plotms
+    from viewer import viewer
+    from gencal import gencal
+    from plotbandpass import plotbandpass
+    from sdbaseline import sdbaseline
+    from sdimaging import sdimaging
+    from sdcal import sdcal
+    from taskinit import msmdtool
+    from taskinit import tbtool
+    from recipes.almahelpers import tsysspwmap
+    
     # sdintimaging imports
 
-    if simple_version >= '5.7':
+    if casa_version >= (5. 7):
         from sdintimaging import sdintimaging
 
 except (ImportError, ModuleNotFoundError):
@@ -67,16 +87,40 @@ except (ImportError, ModuleNotFoundError):
                            tclean,
                            uvcontsub,
                            visstat)
+    
+    # sdintimaging imports
+    
     from casatasks.private import sdint_helper
-
     from .taskSDIntImaging import sdintimaging
 
-    # Rename some things for compatibility
-
+    # singledish processing imports
+    # see some documents at 
+    # - https://casadocs.readthedocs.io/en/stable/api/casatasks.html?highlight=sdcal#single-dish
+    # - https://casadocs.readthedocs.io/en/stable/notebooks/synthesis_calibration.html?highlight=recipes
+    
     iatool = image
     rgtool = regionmanager
     imtool = imager
     msmdtool = msmetadata
     tbtool = table
 
-    simple_version = casatools.version()
+    import almatasks
+    from almatasks.private.almahelpers import tsysspwmap
+    import casaplotms
+    plotms = casaplotms.gotasks.plotms.plotms
+    import casaviewer
+    viewer = casaviewer.gotasks.imview.imview
+    import casashell
+    gencal = casashell.private.gencal.gencal
+    plotbandpass = casashell.private.plotbandpass.plotbandpass
+    sdbaseline = casashell.private.sdbaseline.sdbaseline
+    sdimaging = casashell.private.sdimaging.sdimaging
+    sdcal = casashell.private.sdcal.sdcal
+
+    # version tuple
+    
+    casa_version = casatools.version()
+
+
+
+

--- a/phangsPipeline/casaStuff.py
+++ b/phangsPipeline/casaStuff.py
@@ -40,6 +40,10 @@ try:
         from sdscale import sdscale
         from sdplot import sdplot
 
+    from importasdm import importasdm
+    from listobs import listobs
+    from flagcmd import flagcmd
+    from flagdata import flagdata
     from plotms import plotms
     from viewer import viewer
     from gencal import gencal

--- a/phangsPipeline/casaStuff.py
+++ b/phangsPipeline/casaStuff.py
@@ -98,15 +98,17 @@ except (ImportError, ModuleNotFoundError):
     from .taskSDIntImaging import sdintimaging
 
     # singledish processing imports
-    # see some documents at 
-    # - https://casadocs.readthedocs.io/en/stable/api/casatasks.html?highlight=sdcal#single-dish
-    # - https://casadocs.readthedocs.io/en/stable/notebooks/synthesis_calibration.html?highlight=recipes
-    
+    #   see some documents at 
+    #   - https://casadocs.readthedocs.io/en/stable/api/casatasks.html?highlight=sdcal#single-dish
+    #   - https://casadocs.readthedocs.io/en/stable/notebooks/synthesis_calibration.html?highlight=recipes
+        
     iatool = image
     rgtool = regionmanager
     imtool = imager
     msmdtool = msmetadata
     tbtool = table
+    
+    from casatasks import (importasdm, listobs, flagcmd, flagdata)
 
     import almatasks
     from almatasks.private.almahelpers import tsysspwmap

--- a/phangsPipeline/casaStuff.py
+++ b/phangsPipeline/casaStuff.py
@@ -53,7 +53,7 @@ try:
     
     # sdintimaging imports
 
-    if casa_version >= (5. 7):
+    if casa_version >= (5, 7):
         from sdintimaging import sdintimaging
 
 except (ImportError, ModuleNotFoundError):

--- a/phangsPipeline/clean_call.py
+++ b/phangsPipeline/clean_call.py
@@ -79,21 +79,21 @@ class CleanCall:
         logger.info("Reading a clean input parameter file.")
         logger.info("Reading: "+fname)
 
-        infile = open(fname, 'r')
-        
-        lines_read = 0
-        while True:
-            line = infile.readline()
-            line = line.replace(" ","")
-            line = line.replace("\n","")
-            if len(line) == 0:
-                break
-            if line[0] == '#' or line == '\n':
+        with open(fname, 'r') as infile:
+            
+            lines_read = 0
+            while True:
+                line = infile.readline()
+                line = line.replace(" ","")
+                line = line.replace("\n","")
+                if len(line) == 0:
+                    break
+                if line[0] == '#' or line == '\n':
+                    continue
+                if line.count('=') == 0:
+                    continue
+                exec(re.sub(r'^([a-zA-Z0-9_]+) *= *(.+) *$', r'self.clean_params["\1"] = \2', line) )
                 continue
-            if line.count('=') == 0:
-                continue
-            exec(re.sub(r'^([a-zA-Z0-9_]+) *= *(.+) *$', r'self.clean_params["\1"] = \2', line) )
-            continue
 
         return()
         

--- a/phangsPipeline/handlerImaging.py
+++ b/phangsPipeline/handlerImaging.py
@@ -430,6 +430,10 @@ if casa_enabled:
                 oversamp=5,
                 force_square=False,
                 check_files=True,
+                check_overrides=True,
+                target=None,
+                config=None,
+                product=None,
         ):
             """
             Pick a cell size and imsize for a clean call by inspecting the
@@ -468,16 +472,50 @@ if casa_enabled:
             else:
                 cell, imsize = '0.1arcsec', [1000, 1000]
                 logger.info('DRY RUN skips calling imr.estimate_cell_and_imsize()')
+            
+            # Print info
+            logger.info('cell='+cell+', imsize='+str(imsize))
 
-            logger.info('cell='+cell+'arcsec, imsize='+str(imsize))
+            # Check user-set overriding parameters: deltara deltadec 
+            # (width and height of the field of view in units of arcsec)
+            if check_overrides:
+                # first try to find 'target_config_product' key 'deltara/deltadec' in the override file,
+                # if not found, then find 'target' key 'deltara/deltadec', 
+                # if also not found, then fall back to 'all' key 'deltara/deltadec' if it is not None. 
+                override_keys = []
+                if target is not None and config is not None and product is not None:
+                    override_keys.append(target+'_'+config+'_'+product)
+                if target is not None:
+                    override_keys.append(target)
+                override_keys.append('all')
+                deltara = None
+                deltadec = None
+                for override_key in override_keys:
+                    if deltara is None:
+                        deltara = self._kh.get_overrides(override_key, 'deltara')
+                    if deltadec is None:
+                        deltadec = self._kh.get_overrides(override_key, 'deltadec')
+                cell_arcsec = float(str(cell).replace('arcsec',''))
+                if deltara is not None:
+                    logger.info('applying overriding deltara '+str(deltara)+' arcsec')
+                    deltara = np.abs(float(deltara))
+                    imsize[0] = int(np.ceil(deltara/cell_arcsec))
+                if len(imsize) == 1:
+                    imsize = [imsize[0], imsize[0]]
+                if deltadec is not None:
+                    logger.info('applying overriding deltadec '+str(deltadec)+' arcsec')
+                    deltadec = np.abs(float(deltadec))
+                    imsize[1] = int(np.ceil(deltadec/cell_arcsec))
+            
+                # Print info
+                if deltara is not None or deltadec is not None:
+                    logger.info('cell='+cell+', imsize='+str(imsize))
 
-            logger.info('cell=' + cell + 'arcsec, imsize=' + str(imsize))
-
+            # Set clean call parameters
             clean_call.set_param('cell', cell, nowarning=True)
             clean_call.set_param('imsize', imsize, nowarning=True)
 
             # Return
-
             return (cell, imsize)
 
         @CleanCallFunctionDecorator
@@ -1078,7 +1116,11 @@ if casa_enabled:
             if dynamic_sizing:
                 if cell is None or imsize is None:
                     cell, imsize = self.task_pick_cell_and_imsize(
-                        clean_call=clean_call, force_square=force_square)
+                        clean_call=clean_call, 
+                        force_square=force_square,
+                        check_overrides=True,
+                        target=target, config=config, product=product,
+                        )
                 else:
                     clean_call.set_param('cell', cell, nowarning=True)
                     clean_call.set_param('imsize', imsize, nowarning=True)

--- a/phangsPipeline/handlerImaging.py
+++ b/phangsPipeline/handlerImaging.py
@@ -499,13 +499,13 @@ if casa_enabled:
                 if deltara is not None:
                     logger.info('applying overriding deltara '+str(deltara)+' arcsec')
                     deltara = np.abs(float(deltara))
-                    imsize[0] = int(np.ceil(deltara/cell_arcsec))
+                    imsize[0] = int(np.ceil(deltara/cell_arcsec/2.0)*2) # need an even number
                 if len(imsize) == 1:
                     imsize = [imsize[0], imsize[0]]
                 if deltadec is not None:
                     logger.info('applying overriding deltadec '+str(deltadec)+' arcsec')
                     deltadec = np.abs(float(deltadec))
-                    imsize[1] = int(np.ceil(deltadec/cell_arcsec))
+                    imsize[1] = int(np.ceil(deltadec/cell_arcsec/2.0)*2) # need an even number
             
                 # Print info
                 if deltara is not None or deltadec is not None:

--- a/phangsPipeline/handlerKeys.py
+++ b/phangsPipeline/handlerKeys.py
@@ -152,6 +152,20 @@ class KeyHandler:
         logger.info("Master key reading and checks complete.")
         logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&")
         logger.info("")
+    
+    def _parse_path(self, input_path):
+        """
+        Parse relative path.
+        """
+        if input_path.startswith('/') or input_path.startswith(os.sep):
+            output_path = input_path
+        elif input_path.startswith('~') or input_path.startswith('$'):
+            output_path = os.path.expanduser(input_path)
+        else:
+            output_path = os.path.abspath(input_path)
+        if not (output_path.endswith('/') or output_path.endswith(os.sep)):
+            output_path += '/'
+        return output_path
 
     ##############################################################
     # READ THE MASTER KEY
@@ -222,7 +236,7 @@ class KeyHandler:
             this_value = words[1]
 
             if this_key == 'imaging_root':
-                self._imaging_root = this_value
+                self._imaging_root = self._parse_path(this_value)
                 if first_imaging_root:
                     first_imaging_root = False
                 else:
@@ -230,7 +244,7 @@ class KeyHandler:
                 lines_read += 1
 
             if this_key == 'postprocess_root':
-                self._postprocess_root = this_value
+                self._postprocess_root = self._parse_path(this_value)
                 if first_postprocess_root:
                     first_postprocess_root = False
                 else:
@@ -238,7 +252,7 @@ class KeyHandler:
                 lines_read += 1
 
             if this_key == 'derived_root':
-                self._derived_root = this_value
+                self._derived_root = self._parse_path(this_value)
                 if first_derived_root:
                     first_derived_root = False
                 else:
@@ -246,7 +260,7 @@ class KeyHandler:
                 lines_read += 1
 
             if this_key == 'release_root':
-                self._release_root = this_value
+                self._release_root = self._parse_path(this_value)
                 if first_release_root:
                     first_release_root = False
                 else:
@@ -254,7 +268,7 @@ class KeyHandler:
                 lines_read += 1
 
             if this_key == 'key_dir':
-                self._key_dir = this_value
+                self._key_dir = self._parse_path(this_value)
                 if first_key_dir:
                     first_key_dir = False
                 else:
@@ -262,16 +276,16 @@ class KeyHandler:
                 lines_read += 1
 
             if this_key == 'ms_root':
-                self._ms_roots.append(this_value)
+                self._ms_roots.append(self._parse_path(this_value))
                 lines_read += 1
 
             if this_key == 'singledish_root':
-                self._sd_roots.append(this_value)
+                self._sd_roots.append(self._parse_path(this_value))
                 lines_read += 1
 
             if this_key == 'cleanmask_root':
                 self._cleanmask_root = this_value
-                self._cleanmask_roots.append(this_value)
+                self._cleanmask_roots.append(self._parse_path(this_value))
                 lines_read += 1
 
             if this_key == 'casaversion_key':

--- a/phangsPipeline/handlerPostprocess.py
+++ b/phangsPipeline/handlerPostprocess.py
@@ -349,6 +349,7 @@ class PostProcessHandler(handlerTemplate.HandlerTemplate):
         extra_ext_in = '',
         extra_ext_out = '',
         check_files = True,
+        trim_coarse_beam_edge_channels = False,
         ):
         """
         For one target, product, config combination copy the
@@ -394,6 +395,15 @@ class PostProcessHandler(handlerTemplate.HandlerTemplate):
                 #     infile=indir+infile,
                 #     outfile=outdir+outfile,
                 #     overwrite=True)
+
+        # in case of merged datasets with non-identical frequency setups imaged with per-plane beam, 
+        # some edge channels will have much coarser beam, we trim these edge channels here. 
+        if trim_coarse_beam_edge_channels:
+            ccr.trim_coarse_beam_edge_channels(
+                infile=outdir+fname_dict_out['orig'],
+                inpbfile=outdir+fname_dict_out['pb'],
+                inplace=True,
+            )
 
         return()
 
@@ -1489,7 +1499,8 @@ class PostProcessHandler(handlerTemplate.HandlerTemplate):
         product = None,
         config = None,
         check_files = True,
-        imaging_method='tclean'
+        imaging_method = 'tclean',
+        trim_coarse_beam_edge_channels = False, 
         ):
         """
         Recipe that takes data from imaging through all steps that
@@ -1522,7 +1533,8 @@ class PostProcessHandler(handlerTemplate.HandlerTemplate):
         self.task_stage_interf_data(
             target=target, config=config, product=product,
             check_files=check_files,
-            imaging_method=imaging_method
+            imaging_method=imaging_method,
+            trim_coarse_beam_edge_channels=trim_coarse_beam_edge_channels,
             )
 
         self.task_pbcorr(
@@ -1772,6 +1784,7 @@ class PostProcessHandler(handlerTemplate.HandlerTemplate):
         do_mosaic=False,
         do_cleanup=False,
         do_summarize=False,
+        trim_coarse_beam_edge_channels=False,
         feather_apod=False,
         feather_noapod=False,
         feather_before_mosaic=False,
@@ -1842,7 +1855,9 @@ class PostProcessHandler(handlerTemplate.HandlerTemplate):
 
                 self.recipe_prep_one_target(
                     target = this_target, product = this_product, config = this_config,
-                    check_files = True, imaging_method=imaging_method_prep)
+                    check_files = True, 
+                    trim_coarse_beam_edge_channels = trim_coarse_beam_edge_channels, 
+                    imaging_method = imaging_method_prep)
 
         # Feather the interferometer configuration data that has
         # single dish imaging. We'll return to feather mosaicked

--- a/phangsPipeline/pipelineLogger.py
+++ b/phangsPipeline/pipelineLogger.py
@@ -1,0 +1,178 @@
+
+import logging, os
+
+DefaultLevel = 'DEBUG'
+
+try:
+    from . import casaStuff
+    HasCasaLog = True
+except:
+    HasCasaLog = False
+
+
+class PipelineLogger(logging.getLoggerClass()):
+    """A smart logging module which will redirect to CASA logger if in CASA otherwise to screen and file."""
+    def __init__(self, name, level=None, logfile=None):
+        self.name = name
+        self.origin = ''
+        self.screen_log_format = '[%(levelname).4s] [%(funcName)25s] %(message)s'
+        self.file_log_format = '[%(asctime)-15s] [%(levelname)08s]  [%(name)s] [%(funcName)s] %(message)s'
+        self.file_handler = None
+        super(PipelineLogger, self).__init__(name)
+        self.setup(name, level, logfile)
+    
+    def __enter__(self):
+        #print('PipelineLogger.__enter__')
+        return self
+    
+    def __exit__(self, type, value, traceback):
+        #print('PipelineLogger.__exit__')
+        if self.file_handler is not None:
+            self.file_handler.close()
+    
+    def __del__(self):
+        #print('PipelineLogger.__del__')
+        if self.file_handler is not None:
+            self.file_handler.close()
+    
+    def hasCasaLog(self):
+        global HasCasaLog
+        return HasCasaLog
+        #return ('casalog' in globals())
+    
+    def setCasaOrigin(self):
+        if self.hasCasaLog():
+            self.origin = 'casa'
+            casaStuff.casalog.origin(self.name)
+    
+    def restoreCasaOrigin(self):
+        if self.hasCasaLog():
+            casaStuff.casalog.origin(self.origin)
+    
+    def setup(self, name, level=None, logfile=None):
+        self.name = name
+        if not self.hasCasaLog():
+            if level is None:
+                level = DefaultLevel
+            self.setLevel(logging.getLevelName(level))
+            consoleHandler = logging.StreamHandler()
+            consoleHandler.setFormatter(logging.Formatter(self.screen_log_format))
+            self.addHandler(consoleHandler)
+            if logfile is not None:
+                fileHandler = logging.FileHandler(logfile, mode='a')
+                fileHandler.setFormatter(logging.Formatter(self.file_log_format))
+                self.addHandler(fileHandler)
+                self.file_handler = fileHandler
+    
+    def debug(self, message):
+        if self.hasCasaLog():
+            self.setCasaOrigin()
+            casaStuff.casalog.post(message, 'NORMAL')
+            self.restoreCasaOrigin()
+        else:
+            super(PipelineLogger, self).debug(message)
+    
+    def info(self, message):
+        if self.hasCasaLog():
+            self.setCasaOrigin()
+            casaStuff.casalog.post(message, 'NORMAL')
+            self.restoreCasaOrigin()
+        else:
+            super(PipelineLogger, self).info(message)
+    
+    def warning(self, message):
+        if self.hasCasaLog():
+            self.setCasaOrigin()
+            casaStuff.casalog.post(message, 'WARN')
+            self.restoreCasaOrigin()
+        else:
+            super(PipelineLogger, self).warning(message)
+    
+    def error(self, message):
+        if self.hasCasaLog():
+            self.setCasaOrigin()
+            casaStuff.casalog.post(message, 'SEVERE')
+            self.restoreCasaOrigin()
+        else:
+            super(PipelineLogger, self).error(message)
+
+    def findCallerPy37(self, stack_info=False):
+        """
+        Find the stack frame of the caller so that we can note the source
+        file name, line number and function name.
+        
+        See "lib/python3.7/logging/__init__.py".
+        """
+        currentframe = logging.currentframe # customizing here
+        _srcfile = logging._srcfile # customizing here
+        
+        f = currentframe()
+        #On some versions of IronPython, currentframe() returns None if
+        #IronPython isn't run with -X:Frames.
+        if f is not None:
+            f = f.f_back
+        if f is not None: # customizing here
+            f = f.f_back # customizing here
+        rv = "(unknown file)", 0, "(unknown function)", None
+        while hasattr(f, "f_code"):
+            co = f.f_code
+            filename = os.path.normcase(co.co_filename)
+            if filename == _srcfile:
+                f = f.f_back
+                continue
+            sinfo = None
+            if stack_info:
+                sio = io.StringIO()
+                sio.write('Stack (most recent call last):\n')
+                traceback.print_stack(f, file=sio)
+                sinfo = sio.getvalue()
+                if sinfo[-1] == '\n':
+                    sinfo = sinfo[:-1]
+                sio.close()
+            rv = (co.co_filename, f.f_lineno, co.co_name, sinfo)
+            break
+        return rv
+
+    def findCaller(self, stack_info=False, stacklevel=1):
+        """
+        Find the stack frame of the caller so that we can note the source
+        file name, line number and function name.
+        
+        See "lib/python3.9/logging/__init__.py".
+        """
+        currentframe = logging.currentframe # customizing here
+        _srcfile = logging._srcfile # customizing here
+        
+        f = currentframe()
+        #On some versions of IronPython, currentframe() returns None if
+        #IronPython isn't run with -X:Frames.
+        if f is not None:
+            f = f.f_back
+        if f is not None: # customizing here
+            f = f.f_back # customizing here
+        orig_f = f
+        while f and stacklevel > 1:
+            f = f.f_back
+            stacklevel -= 1
+        if not f:
+            f = orig_f
+        rv = "(unknown file)", 0, "(unknown function)", None
+        while hasattr(f, "f_code"):
+            co = f.f_code
+            filename = os.path.normcase(co.co_filename)
+            if filename == _srcfile:
+                f = f.f_back
+                continue
+            sinfo = None
+            if stack_info:
+                sio = io.StringIO()
+                sio.write('Stack (most recent call last):\n')
+                traceback.print_stack(f, file=sio)
+                sinfo = sio.getvalue()
+                if sinfo[-1] == '\n':
+                    sinfo = sinfo[:-1]
+                sio.close()
+            rv = (co.co_filename, f.f_lineno, co.co_name, sinfo)
+            break
+        return rv
+

--- a/phangsPipeline/pipelineLogger.py
+++ b/phangsPipeline/pipelineLogger.py
@@ -67,7 +67,7 @@ class PipelineLogger(logging.getLoggerClass()):
     def debug(self, message):
         if self.hasCasaLog():
             self.setCasaOrigin()
-            casaStuff.casalog.post(message, 'NORMAL')
+            casaStuff.casalog.post(message, 'DEBUGGING')
             self.restoreCasaOrigin()
         else:
             super(PipelineLogger, self).debug(message)
@@ -96,42 +96,42 @@ class PipelineLogger(logging.getLoggerClass()):
         else:
             super(PipelineLogger, self).error(message)
 
-    def findCallerPy37(self, stack_info=False):
-        """
-        Find the stack frame of the caller so that we can note the source
-        file name, line number and function name.
-        
-        See "lib/python3.7/logging/__init__.py".
-        """
-        currentframe = logging.currentframe # customizing here
-        _srcfile = logging._srcfile # customizing here
-        
-        f = currentframe()
-        #On some versions of IronPython, currentframe() returns None if
-        #IronPython isn't run with -X:Frames.
-        if f is not None:
-            f = f.f_back
-        if f is not None: # customizing here
-            f = f.f_back # customizing here
-        rv = "(unknown file)", 0, "(unknown function)", None
-        while hasattr(f, "f_code"):
-            co = f.f_code
-            filename = os.path.normcase(co.co_filename)
-            if filename == _srcfile:
-                f = f.f_back
-                continue
-            sinfo = None
-            if stack_info:
-                sio = io.StringIO()
-                sio.write('Stack (most recent call last):\n')
-                traceback.print_stack(f, file=sio)
-                sinfo = sio.getvalue()
-                if sinfo[-1] == '\n':
-                    sinfo = sinfo[:-1]
-                sio.close()
-            rv = (co.co_filename, f.f_lineno, co.co_name, sinfo)
-            break
-        return rv
+    #def findCallerPy37(self, stack_info=False):
+    #    """
+    #    Find the stack frame of the caller so that we can note the source
+    #    file name, line number and function name.
+    #    
+    #    See "lib/python3.7/logging/__init__.py".
+    #    """
+    #    currentframe = logging.currentframe # customizing here
+    #    _srcfile = logging._srcfile # customizing here
+    #    
+    #    f = currentframe()
+    #    #On some versions of IronPython, currentframe() returns None if
+    #    #IronPython isn't run with -X:Frames.
+    #    if f is not None:
+    #        f = f.f_back
+    #    if f is not None: # customizing here
+    #        f = f.f_back # customizing here
+    #    rv = "(unknown file)", 0, "(unknown function)", None
+    #    while hasattr(f, "f_code"):
+    #        co = f.f_code
+    #        filename = os.path.normcase(co.co_filename)
+    #        if filename == _srcfile:
+    #            f = f.f_back
+    #            continue
+    #        sinfo = None
+    #        if stack_info:
+    #            sio = io.StringIO()
+    #            sio.write('Stack (most recent call last):\n')
+    #            traceback.print_stack(f, file=sio)
+    #            sinfo = sio.getvalue()
+    #            if sinfo[-1] == '\n':
+    #                sinfo = sinfo[:-1]
+    #            sio.close()
+    #        rv = (co.co_filename, f.f_lineno, co.co_name, sinfo)
+    #        break
+    #    return rv
 
     def findCaller(self, stack_info=False, stacklevel=1):
         """

--- a/phangsPipeline/taskSDIntImaging.py
+++ b/phangsPipeline/taskSDIntImaging.py
@@ -20,7 +20,7 @@ logger.setLevel(logging.DEBUG)
 
 from casatasks.private.imagerhelpers.imager_base import PySynthesisImager
 from casatasks.private.imagerhelpers.input_parameters import ImagerParameters
-from casatasks.private.cleanhelper import write_tclean_history, get_func_params
+#from casatasks.private.cleanhelper import write_tclean_history, get_func_params
 from casatasks.private.sdint_helper import *
 
 # Pull MPI in, if available
@@ -723,6 +723,7 @@ def sdintimaging(
     # so they won't be picked up. They need time to disappear on NFS or slow hw.
     # Copied from tclean.
     try:
+        from casatasks.private.cleanhelper import write_tclean_history, get_func_params
         params = get_func_params(sdintimaging, locals())
         write_tclean_history(imagename, 'sdintimaging', params, casaStuff.casalog)
     except Exception as exc:

--- a/phangsPipelineTests/__init__.py
+++ b/phangsPipelineTests/__init__.py
@@ -6,7 +6,40 @@ from .test_casaFeatherRoutines import TestingCasaFeatherRoutines
 from .test_casaFeatherRoutines import TestingCasaFeatherRoutinesInCasa
 from .test_handlerKeys import TestingHandlerKeys
 from .test_handlerKeys import TestingHandlerKeysInCasa
-from .test_handlerImaging import TestingHandlerImaging
-from .test_handlerImaging import TestingHandlerImagingInCasa
 from .test_handlerVis import TestingHandlerVis
 from .test_handlerVis import TestingHandlerVisInCasa
+from .test_handlerImaging import TestingHandlerImaging
+from .test_handlerImaging import TestingHandlerImagingInCasa
+
+import phangsPipeline
+import unittest
+
+class TestingAllInCasa():
+    """docstring for TestingHandlerKeysInCasa
+    
+    To run all tests, run following command in CASA:
+        sys.path.append('../analysis_scripts')
+        sys.path.append('.')
+        import phangsPipelineTests
+        phangsPipelineTests.TestingAllInCasa().run()
+    
+    """
+    
+    def __init__(self):
+        pass
+    
+    def suite(self=None):
+        testsuite = unittest.TestSuite()
+        testsuite.addTest(unittest.makeSuite(TestingPipelineLogger))
+        testsuite.addTest(unittest.makeSuite(TestingCasaCubeRoutines))
+        testsuite.addTest(unittest.makeSuite(TestingCasaFeatherRoutines))
+        testsuite.addTest(unittest.makeSuite(TestingHandlerKeys))
+        testsuite.addTest(unittest.makeSuite(TestingHandlerVis))
+        testsuite.addTest(unittest.makeSuite(TestingHandlerImaging))
+        return testsuite
+    
+    def run(self):
+        unittest.main(defaultTest='phangsPipelineTests.TestingAllInCasa.suite', 
+                      verbosity=2, 
+                      exit=False)
+

--- a/phangsPipelineTests/__init__.py
+++ b/phangsPipelineTests/__init__.py
@@ -1,0 +1,4 @@
+from .test_pipelineLogger import TestingPipelineLogger
+from .test_pipelineLogger import TestingPipelineLoggerInCasa
+from .test_casaCubeRoutines import TestingCasaCubeRoutines
+from .test_casaCubeRoutines import TestingCasaCubeRoutinesInCasa

--- a/phangsPipelineTests/__init__.py
+++ b/phangsPipelineTests/__init__.py
@@ -4,3 +4,9 @@ from .test_casaCubeRoutines import TestingCasaCubeRoutines
 from .test_casaCubeRoutines import TestingCasaCubeRoutinesInCasa
 from .test_casaFeatherRoutines import TestingCasaFeatherRoutines
 from .test_casaFeatherRoutines import TestingCasaFeatherRoutinesInCasa
+from .test_handlerKeys import TestingHandlerKeys
+from .test_handlerKeys import TestingHandlerKeysInCasa
+from .test_handlerImaging import TestingHandlerImaging
+from .test_handlerImaging import TestingHandlerImagingInCasa
+from .test_handlerVis import TestingHandlerVis
+from .test_handlerVis import TestingHandlerVisInCasa

--- a/phangsPipelineTests/__init__.py
+++ b/phangsPipelineTests/__init__.py
@@ -2,3 +2,5 @@ from .test_pipelineLogger import TestingPipelineLogger
 from .test_pipelineLogger import TestingPipelineLoggerInCasa
 from .test_casaCubeRoutines import TestingCasaCubeRoutines
 from .test_casaCubeRoutines import TestingCasaCubeRoutinesInCasa
+from .test_casaFeatherRoutines import TestingCasaFeatherRoutines
+from .test_casaFeatherRoutines import TestingCasaFeatherRoutinesInCasa

--- a/phangsPipelineTests/test_casaCubeRoutines.py
+++ b/phangsPipelineTests/test_casaCubeRoutines.py
@@ -2,10 +2,18 @@
 How to run this test inside CASA:
 
 ```
-sys.path.append('../scripts/analysis_scripts')
-sys.path.append('../scripts/phangs_imaging_scripts')
+sys.path.append('../casa_analysis_scripts')
+sys.path.append('../analysis_scripts')
+sys.path.append('.')
+import importlib
+#importlib.reload = reload
+import phangsPipeline
+importlib.reload(phangsPipeline)
+importlib.reload(phangsPipeline.casaCubeRoutines)
+importlib.reload(phangsPipeline.casaFeatherRoutines)
 import phangsPipelineTests
 importlib.reload(phangsPipelineTests)
+importlib.reload(phangsPipelineTests.test_casaCubeRoutines)
 phangsPipelineTests.TestingCasaCubeRoutinesInCasa().run()
 ```
 """

--- a/phangsPipelineTests/test_casaCubeRoutines.py
+++ b/phangsPipelineTests/test_casaCubeRoutines.py
@@ -142,6 +142,10 @@ class TestingCasaCubeRoutines(unittest.TestCase):
         self.import_test_image('test.fits', 'test3.image', overwrite=False)
         ccr.multiply_cube_by_value('test3.image', 5.0, 'Jy/beam')
         shutil.rmtree('test3.image')
+        
+    def tearDown(self):
+        if os.path.isfile('test.fits'):
+            os.remove('test.fits')
 
 
 class TestingCasaCubeRoutinesInCasa():

--- a/phangsPipelineTests/test_casaCubeRoutines.py
+++ b/phangsPipelineTests/test_casaCubeRoutines.py
@@ -1,0 +1,173 @@
+"""
+How to run this test inside CASA:
+
+```
+sys.path.append('../scripts/analysis_scripts')
+sys.path.append('../scripts/phangs_imaging_scripts')
+import phangsPipelineTests
+importlib.reload(phangsPipelineTests)
+phangsPipelineTests.TestingCasaCubeRoutinesInCasa().run()
+```
+"""
+
+import os, sys, shutil
+import unittest
+
+
+class TestingCasaCubeRoutines(unittest.TestCase):
+    """docstring for TestingCasaCubeRoutines"""
+    
+    def __init__(self, *args, **kwargs):
+        super(TestingCasaCubeRoutines, self).__init__(*args, **kwargs)
+        for filename in ['test.fits', 'test.image', 'test2.image', 'test3.image']:
+            if os.path.isfile(filename):
+                os.remove(filename)
+            elif os.path.isdir(filename):
+                shutil.rmtree(filename)
+    
+    def set_sys_path(self):
+        if '__file__' in globals():
+            script_dir = os.path.dirname(os.path.abspath(__file__))+os.sep+'analysis_scripts'
+            if script_dir not in sys.path:
+                sys.path.insert(1, script_dir)
+            script_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            if script_dir not in sys.path:
+                sys.path.insert(1, script_dir)
+        #print('sys.path', sys.path)
+    
+    def make_test_image(self, filename = 'test.fits', nx = 3000, ny = 3000, nchan = 393, nstokes = None, radius = 800.0, overwrite = True):
+        import numpy as np
+        try:
+            from astropy.io import fits
+        except:
+            import pyfits as fits
+        
+        if os.path.isfile(filename): 
+            if overwrite:
+                shutil.move(filename, filename+'.backup')
+            else:
+                return
+        
+        data = np.zeros([nchan, ny, nx], dtype=np.float32)
+        header = fits.Header()
+        header['NAXIS'] = 3
+        header['NAXIS1'] = nx
+        header['NAXIS2'] = ny
+        header['NAXIS3'] = nchan
+        header['RADESYS'] = 'FK5'
+        header['SPECSYS'] = 'LSRK'
+        header['EQUINOX'] = 2000.0
+        header['CTYPE1'] = 'RA---TAN'
+        header['CTYPE2'] = 'DEC--TAN'
+        header['CTYPE3'] = 'VRAD'
+        header['CUNIT1'] = 'deg'
+        header['CUNIT2'] = 'deg'
+        header['CUNIT3'] = 'm/s'
+        header['CRVAL1'] = 1.0
+        header['CRVAL2'] = 1.0
+        header['CRVAL3'] = 1000.0
+        header['CRPIX1'] = 1.0
+        header['CRPIX2'] = 1.0
+        header['CRPIX3'] = 1.0
+        header['CDELT1'] = -0.2/3600.0
+        header['CDELT2'] = 0.2/3600.0
+        header['CDELT3'] = 1000.0
+        header['RESTFRQ'] = 2.30538e11
+        header['TELESCOP'] = 'ALMA'
+        header['OBJECT'] = ' '
+        header['BUNIT'] = 'Jy/beam'
+        header['BTYPE'] = 'Intensity'
+        header['BMAJ'] = 0.3/3600.0
+        header['BMIN'] = 0.3/3600.0
+        header['BPA'] = 0.0
+        if nstokes is not None:
+            header['NAXIS'] = 4
+            header['NAXIS4'] = nstokes
+            header['CTYPE4'] = 'STOKES'
+            header['CUNIT4'] = ''
+            header['CRVAL4'] = 1.0
+            header['CRPIX4'] = 1.0
+            header['CDELT4'] = 1.0
+        gy, gx = np.mgrid[:ny, :nx]
+        cy, cx = (ny-1)/2.0, (nx-1)/2.0
+        gr2 = ((gy-cy)**2+(gx-cx)**2)
+        radius2 = radius**2
+        for ichan in range(nchan):
+            #sig = 30.0 - np.abs(ichan-(nchan-1)/2.0)/nchan*15.0
+            #data[ichan] = np.exp(-0.5*gr2/(sig**2))
+            #data[ichan][gr2>radius**2] = np.nan
+            data[ichan][gr2<=radius2] = 1.0
+        hdu = fits.PrimaryHDU(data=data, header=header)
+        hdu.writeto(filename)
+        
+        self.assertTrue(os.path.isfile(filename))
+        
+        if os.path.isfile(filename) and os.path.isfile(filename+'.backup'):
+            os.remove(filename+'.backup')
+    
+    def import_test_image(self, filename, outname, overwrite = True):
+        from phangsPipeline import casaStuff
+        if os.path.exists(outname):
+            if overwrite:
+                shutil.rmtree(outname)
+            else:
+                return
+        casaStuff.importfits(filename, outname)
+        self.assertTrue(os.path.isdir(outname))
+    
+    def test_get_mask(self):
+        self.set_sys_path()
+        from phangsPipeline import casaCubeRoutines as ccr
+        self.make_test_image('test.fits', overwrite=False)
+        self.import_test_image('test.fits', 'test.image', overwrite=False)
+        self.assertTrue(os.path.isdir('test.image'))
+        ccr.get_mask('test.image')
+        shutil.rmtree('test.image')
+    
+    def test_copy_mask(self):
+        self.set_sys_path()
+        from phangsPipeline import casaCubeRoutines as ccr
+        self.make_test_image('test.fits', overwrite=False)
+        self.import_test_image('test.fits', 'test.image', overwrite=False)
+        self.import_test_image('test.fits', 'test2.image', overwrite=False)
+        ccr.copy_mask('test.image', 'test2.image')
+        shutil.rmtree('test.image')
+        shutil.rmtree('test2.image')
+    
+    def test_multiply_cube_by_value(self):
+        self.set_sys_path()
+        from phangsPipeline import casaStuff
+        from phangsPipeline import casaCubeRoutines as ccr
+        self.make_test_image('test.fits', overwrite=False)
+        self.import_test_image('test.fits', 'test3.image', overwrite=False)
+        ccr.multiply_cube_by_value('test3.image', 5.0, 'Jy/beam')
+        shutil.rmtree('test3.image')
+
+
+class TestingCasaCubeRoutinesInCasa():
+    """docstring for TestingCasaCubeRoutinesInCasa"""
+    
+    def __init__(self):
+        pass
+    
+    def suite(self=None):
+        #modules = (
+        #    'TestingCasaCubeRoutines',
+        #)
+        testsuite = unittest.TestSuite()
+        #for module in map(__import__, modules):
+        #    testsuite.addTest(unittest.findTestCases(module))
+        testsuite.addTest(unittest.makeSuite(TestingCasaCubeRoutines))
+        return testsuite
+    
+    def run(self):
+        #del sys.modules['phangsPipelineTests']
+        #del sys.modules['phangsPipelineTests.test_casaCubeRoutines']
+        #import phangsPipelineTests; phangsPipelineTests.TestingCasaCubeRoutinesInCasa().run() 
+        unittest.main(defaultTest='phangsPipelineTests.TestingCasaCubeRoutinesInCasa.suite', exit=False)
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+

--- a/phangsPipelineTests/test_casaCubeRoutines.py
+++ b/phangsPipelineTests/test_casaCubeRoutines.py
@@ -27,23 +27,20 @@ class TestingCasaCubeRoutines(unittest.TestCase):
     
     def __init__(self, *args, **kwargs):
         super(TestingCasaCubeRoutines, self).__init__(*args, **kwargs)
+        import phangsPipeline
+        self.current_dir = os.getcwd()
+        self.module_dir = os.path.dirname(os.path.abspath(phangsPipeline.__path__[0]))
+        self.working_dir = os.path.join(self.module_dir, 'phangsPipelineTests')
+        self.test_data_dir = os.path.join(self.working_dir, 'test_data')
+        self.test_keys_dir = os.path.join(self.working_dir, 'test_keys')
         for filename in ['test.fits', 'test.image', 'test2.image', 'test3.image']:
-            if os.path.isfile(filename):
-                os.remove(filename)
-            elif os.path.isdir(filename):
-                shutil.rmtree(filename)
+            filepath = os.path.join(self.test_data_dir, filename)
+            if os.path.isfile(filepath):
+                os.remove(filepath)
+            elif os.path.isdir(filepath):
+                shutil.rmtree(filepath)
     
-    def set_sys_path(self):
-        if '__file__' in globals():
-            script_dir = os.path.dirname(os.path.abspath(__file__))+os.sep+'analysis_scripts'
-            if script_dir not in sys.path:
-                sys.path.insert(1, script_dir)
-            script_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-            if script_dir not in sys.path:
-                sys.path.insert(1, script_dir)
-        #print('sys.path', sys.path)
-    
-    def make_test_image(self, filename = 'test.fits', nx = 3000, ny = 3000, nchan = 393, nstokes = None, radius = 800.0, overwrite = True):
+    def make_test_image(self, filename, nx = 3000, ny = 3000, nchan = 393, nstokes = None, radius = 800.0, overwrite = True):
         import numpy as np
         try:
             from astropy.io import fits
@@ -124,36 +121,39 @@ class TestingCasaCubeRoutines(unittest.TestCase):
         self.assertTrue(os.path.isdir(outname))
     
     def test_get_mask(self):
-        self.set_sys_path()
         from phangsPipeline import casaCubeRoutines as ccr
-        self.make_test_image('test.fits', overwrite=False)
-        self.import_test_image('test.fits', 'test.image', overwrite=False)
-        self.assertTrue(os.path.isdir('test.image'))
-        ccr.get_mask('test.image')
-        shutil.rmtree('test.image')
+        self.make_test_image(self.test_data_dir+os.sep+'test.fits', overwrite=False)
+        self.import_test_image(self.test_data_dir+os.sep+'test.fits', 
+                               self.test_data_dir+os.sep+'test.image', overwrite=False)
+        self.assertTrue(os.path.isdir(self.test_data_dir+os.sep+'test.image'))
+        ccr.get_mask(self.test_data_dir+os.sep+'test.image')
+        shutil.rmtree(self.test_data_dir+os.sep+'test.image')
     
     def test_copy_mask(self):
-        self.set_sys_path()
         from phangsPipeline import casaCubeRoutines as ccr
-        self.make_test_image('test.fits', overwrite=False)
-        self.import_test_image('test.fits', 'test.image', overwrite=False)
-        self.import_test_image('test.fits', 'test2.image', overwrite=False)
-        ccr.copy_mask('test.image', 'test2.image')
-        shutil.rmtree('test.image')
-        shutil.rmtree('test2.image')
+        self.make_test_image(self.test_data_dir+os.sep+'test.fits', overwrite=False)
+        self.import_test_image(self.test_data_dir+os.sep+'test.fits', 
+                               self.test_data_dir+os.sep+'test.image', overwrite=False)
+        self.import_test_image(self.test_data_dir+os.sep+'test.fits', 
+                               self.test_data_dir+os.sep+'test2.image', overwrite=False)
+        ccr.copy_mask(self.test_data_dir+os.sep+'test.image', 
+                      self.test_data_dir+os.sep+'test2.image')
+        shutil.rmtree(self.test_data_dir+os.sep+'test.image')
+        shutil.rmtree(self.test_data_dir+os.sep+'test2.image')
     
     def test_multiply_cube_by_value(self):
-        self.set_sys_path()
         from phangsPipeline import casaStuff
         from phangsPipeline import casaCubeRoutines as ccr
-        self.make_test_image('test.fits', overwrite=False)
-        self.import_test_image('test.fits', 'test3.image', overwrite=False)
-        ccr.multiply_cube_by_value('test3.image', 5.0, 'Jy/beam')
-        shutil.rmtree('test3.image')
+        self.make_test_image(self.test_data_dir+os.sep+'test.fits', overwrite=False)
+        self.import_test_image(self.test_data_dir+os.sep+'test.fits', 
+                               self.test_data_dir+os.sep+'test3.image', overwrite=False)
+        ccr.multiply_cube_by_value(self.test_data_dir+os.sep+'test3.image', 
+                                   5.0, 'Jy/beam')
+        shutil.rmtree(self.test_data_dir+os.sep+'test3.image')
         
     def tearDown(self):
-        if os.path.isfile('test.fits'):
-            os.remove('test.fits')
+        if os.path.isfile(self.test_data_dir+os.sep+'test.fits'):
+            os.remove(self.test_data_dir+os.sep+'test.fits')
 
 
 
@@ -164,19 +164,11 @@ class TestingCasaCubeRoutinesInCasa():
         pass
     
     def suite(self=None):
-        #modules = (
-        #    'TestingCasaCubeRoutines',
-        #)
         testsuite = unittest.TestSuite()
-        #for module in map(__import__, modules):
-        #    testsuite.addTest(unittest.findTestCases(module))
         testsuite.addTest(unittest.makeSuite(TestingCasaCubeRoutines))
         return testsuite
     
     def run(self):
-        #del sys.modules['phangsPipelineTests']
-        #del sys.modules['phangsPipelineTests.test_casaCubeRoutines']
-        #import phangsPipelineTests; phangsPipelineTests.TestingCasaCubeRoutinesInCasa().run() 
         unittest.main(defaultTest='phangsPipelineTests.TestingCasaCubeRoutinesInCasa.suite', exit=False)
 
 

--- a/phangsPipelineTests/test_casaCubeRoutines.py
+++ b/phangsPipelineTests/test_casaCubeRoutines.py
@@ -148,6 +148,7 @@ class TestingCasaCubeRoutines(unittest.TestCase):
             os.remove('test.fits')
 
 
+
 class TestingCasaCubeRoutinesInCasa():
     """docstring for TestingCasaCubeRoutinesInCasa"""
     
@@ -169,6 +170,7 @@ class TestingCasaCubeRoutinesInCasa():
         #del sys.modules['phangsPipelineTests.test_casaCubeRoutines']
         #import phangsPipelineTests; phangsPipelineTests.TestingCasaCubeRoutinesInCasa().run() 
         unittest.main(defaultTest='phangsPipelineTests.TestingCasaCubeRoutinesInCasa.suite', exit=False)
+
 
 
 if __name__ == '__main__':

--- a/phangsPipelineTests/test_casaFeatherRoutines.py
+++ b/phangsPipelineTests/test_casaFeatherRoutines.py
@@ -5,6 +5,8 @@ How to run this test inside CASA:
 sys.path.append('../casa_analysis_scripts')
 sys.path.append('../analysis_scripts')
 sys.path.append('.')
+import importlib
+#importlib.reload = reload
 import phangsPipeline
 importlib.reload(phangsPipeline)
 importlib.reload(phangsPipeline.casaCubeRoutines)

--- a/phangsPipelineTests/test_casaFeatherRoutines.py
+++ b/phangsPipelineTests/test_casaFeatherRoutines.py
@@ -1,0 +1,205 @@
+"""
+How to run this test inside CASA:
+
+```
+sys.path.append('../casa_analysis_scripts')
+sys.path.append('../analysis_scripts')
+sys.path.append('.')
+import phangsPipeline
+importlib.reload(phangsPipeline)
+importlib.reload(phangsPipeline.casaCubeRoutines)
+importlib.reload(phangsPipeline.casaFeatherRoutines)
+import phangsPipelineTests
+importlib.reload(phangsPipelineTests)
+importlib.reload(phangsPipelineTests.test_casaFeatherRoutines)
+phangsPipelineTests.TestingCasaFeatherRoutinesInCasa().run()
+```
+
+What will be tested:
+
+```
+prep_sd_for_feather
+
+```
+"""
+
+import os, sys, shutil
+import unittest
+
+
+class TestingCasaFeatherRoutines(unittest.TestCase):
+    """docstring for TestingCasaFeatherRoutines"""
+    
+    def __init__(self, *args, **kwargs):
+        super(TestingCasaFeatherRoutines, self).__init__(*args, **kwargs)
+        self.test_data_dir = os.path.dirname(os.path.abspath(__file__))+os.sep+'test_data'
+        self.test_sd_file = ''
+        self.test_interf_file = ''
+    
+    def set_sys_path(self):
+        if '__file__' in globals():
+            script_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))+os.sep+'casa_analysis_scripts'
+            if os.path.isdir(script_dir) and script_dir not in sys.path:
+                sys.path.insert(1, script_dir)
+            script_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))+os.sep+'analysis_scripts'
+            if os.path.isdir(script_dir) and script_dir not in sys.path:
+                sys.path.insert(1, script_dir)
+            script_dir = os.path.dirname(os.path.abspath(__file__))+os.sep+'casa_analysis_scripts'
+            if os.path.isdir(script_dir) and script_dir not in sys.path:
+                sys.path.insert(1, script_dir)
+            script_dir = os.path.dirname(os.path.abspath(__file__))+os.sep+'analysis_scripts'
+            if os.path.isdir(script_dir) and script_dir not in sys.path:
+                sys.path.insert(1, script_dir)
+            script_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            if os.path.isdir(script_dir) and script_dir not in sys.path:
+                sys.path.insert(1, script_dir)
+        #print('sys.path', sys.path)
+    
+    def import_test_image(self, filename, outname, overwrite = True):
+        from phangsPipeline import casaStuff
+        if os.path.exists(outname):
+            if overwrite:
+                shutil.rmtree(outname)
+            else:
+                return
+        casaStuff.importfits(filename, outname)
+        self.assertTrue(os.path.isdir(outname))
+    
+    def fetch_test_data(self):
+        import ssl
+        import urllib.request
+        import tarfile
+        import numpy as np
+        try:
+            from astropy.io import fits
+        except:
+            import pyfits as fits
+        
+        self.test_sd_file = self.test_data_dir+os.sep+'ALMA_TP.NGC1808.CO21_5kmsres.image.fits'
+        self.test_interf_file = self.test_data_dir+os.sep+'ngc1808_12m+7m_co21_pbcorr_trimmed_k.fits'
+        
+        use_M100 = False
+        if use_M100:
+            self.test_sd_file = self.test_data_dir+os.sep+'M100_Band3_ACA_ReferenceImages/M100_TP_CO_cube.bl.image.fits'
+            self.test_interf_file = self.test_data_dir+os.sep+'M100_Band3_ACA_ReferenceImages/M100_7m_CO.image.fits'
+            
+            if not os.path.isfile(self.test_sd_file) and \
+               not os.path.isfile(self.test_interf_file):
+                
+                if not os.path.isdir(self.test_data_dir):
+                    os.makedirs(self.test_data_dir)
+                if not os.path.isfile(self.test_data_dir+os.sep+'M100_Band3_ACA_ReferenceImages.tgz'):
+                    with urllib.request.urlopen(
+                        'https://almascience.eso.org/almadata/sciver/M100Band3ACA/M100_Band3_ACA_ReferenceImages.tgz',
+                        context = ssl._create_unverified_context()
+                        ) as fp_from, open(
+                        self.test_data_dir+os.sep+'M100_Band3_ACA_ReferenceImages.tgz', 'wb'
+                        ) as fp_to:
+                        fp_to.write(fp_from.read())
+                
+                self.assertTrue(os.path.isfile(self.test_data_dir+os.sep+'M100_Band3_ACA_ReferenceImages.tgz'))
+                
+                with tarfile.open(self.test_data_dir+os.sep+'M100_Band3_ACA_ReferenceImages.tgz', 'r:gz') as tgz:
+                    #tgz.extract(
+                    #    'M100_Band3_ACA_ReferenceImages/M100_TP_CO_cube.bl.image.fits', 
+                    #    self.test_data_dir
+                    #    )
+                    #tgz.extract(
+                    #    'M100_Band3_ACA_ReferenceImages/M100_7m_CO.image.fits', 
+                    #    self.test_data_dir
+                    #    )
+                    tgz.extractall(
+                        self.test_data_dir, 
+                        members=[
+                            tgz.getmember('M100_Band3_ACA_ReferenceImages/M100_TP_CO_cube.bl.image.fits'), 
+                            tgz.getmember('M100_Band3_ACA_ReferenceImages/M100_7m_CO.image.fits')
+                            ],
+                        )
+        
+        if not os.path.isfile(self.test_sd_file):
+            print('Error! Test data file is not found: '+os.path.isfile(self.test_sd_file))
+        if not os.path.isfile(self.test_interf_file):
+            print('Error! Test data file is not found: '+os.path.isfile(self.test_interf_file))
+        self.assertTrue(os.path.isfile(self.test_sd_file))
+        self.assertTrue(os.path.isfile(self.test_interf_file))
+    
+    def test_prep_sd_for_feather(self):
+        self.set_sys_path()
+        self.fetch_test_data()
+        from phangsPipeline import casaFeatherRoutines as cfr
+        if self.test_interf_file.endswith('.fits'):
+            self.import_test_image(
+                self.test_interf_file, 
+                self.test_data_dir+os.sep+'interf_data_to_feather.image.tmp', 
+                )
+        else:
+            shutil.copy2(
+                self.test_interf_file, 
+                self.test_data_dir+os.sep+'interf_data_to_feather.image.tmp', 
+                )
+        from casatasks import imhead
+        if imhead(self.test_data_dir+os.sep+'interf_data_to_feather.image.tmp')['ndim'] == 3:
+            do_dropdeg = True
+        else:
+            do_dropdeg = False
+        cfr.prep_sd_for_feather(
+                sdfile_in=self.test_sd_file,
+                sdfile_out=self.test_data_dir+os.sep+'sd_data_to_feather.image.tmp',
+                interf_file=self.test_data_dir+os.sep+'interf_data_to_feather.image.tmp',
+                do_dropdeg=do_dropdeg,
+                overwrite=True,
+            )
+    
+    def test_feather_two_cubes(self):
+        self.set_sys_path()
+        self.fetch_test_data()
+        from phangsPipeline import casaFeatherRoutines as cfr
+        self.test_prep_sd_for_feather()
+        cfr.feather_two_cubes(
+                interf_file=self.test_data_dir+os.sep+'interf_data_to_feather.image.tmp',
+                sd_file=self.test_data_dir+os.sep+'sd_data_to_feather.image.tmp',
+                out_file=self.test_data_dir+os.sep+'feathered.image.tmp',
+                do_blank=True,
+                do_apodize=False,
+                overwrite=True,
+            )
+        
+    def tearDown(self):
+        #pass
+        if os.path.exists(self.test_data_dir+os.sep+'sd_data_to_feather.image.tmp'):
+           shutil.rmtree(self.test_data_dir+os.sep+'sd_data_to_feather.image.tmp')
+        if os.path.exists(self.test_data_dir+os.sep+'interf_data_to_feather.image.tmp'):
+           shutil.rmtree(self.test_data_dir+os.sep+'interf_data_to_feather.image.tmp')
+        if os.path.exists(self.test_data_dir+os.sep+'feathered.image.tmp'):
+           shutil.rmtree(self.test_data_dir+os.sep+'feathered.image.tmp')
+
+
+
+class TestingCasaFeatherRoutinesInCasa():
+    """docstring for TestingCasaFeatherRoutinesInCasa"""
+    
+    def __init__(self):
+        pass
+    
+    def suite(self=None):
+        #modules = (
+        #    'TestingCasaFeatherRoutines',
+        #)
+        testsuite = unittest.TestSuite()
+        #for module in map(__import__, modules):
+        #    testsuite.addTest(unittest.findTestCases(module))
+        testsuite.addTest(unittest.makeSuite(TestingCasaFeatherRoutines))
+        return testsuite
+    
+    def run(self):
+        #del sys.modules['phangsPipelineTests']
+        #del sys.modules['phangsPipelineTests.test_CasaFeatherRoutines']
+        #import phangsPipelineTests; phangsPipelineTests.TestingCasaFeatherRoutinesInCasa().run() 
+        unittest.main(defaultTest='phangsPipelineTests.TestingCasaFeatherRoutinesInCasa.suite', exit=False)
+
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+

--- a/phangsPipelineTests/test_casaFeatherRoutines.py
+++ b/phangsPipelineTests/test_casaFeatherRoutines.py
@@ -34,28 +34,14 @@ class TestingCasaFeatherRoutines(unittest.TestCase):
     
     def __init__(self, *args, **kwargs):
         super(TestingCasaFeatherRoutines, self).__init__(*args, **kwargs)
-        self.test_data_dir = os.path.dirname(os.path.abspath(__file__))+os.sep+'test_data'
-        self.test_sd_file = ''
-        self.test_interf_file = ''
-    
-    def set_sys_path(self):
-        if '__file__' in globals():
-            script_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))+os.sep+'casa_analysis_scripts'
-            if os.path.isdir(script_dir) and script_dir not in sys.path:
-                sys.path.insert(1, script_dir)
-            script_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))+os.sep+'analysis_scripts'
-            if os.path.isdir(script_dir) and script_dir not in sys.path:
-                sys.path.insert(1, script_dir)
-            script_dir = os.path.dirname(os.path.abspath(__file__))+os.sep+'casa_analysis_scripts'
-            if os.path.isdir(script_dir) and script_dir not in sys.path:
-                sys.path.insert(1, script_dir)
-            script_dir = os.path.dirname(os.path.abspath(__file__))+os.sep+'analysis_scripts'
-            if os.path.isdir(script_dir) and script_dir not in sys.path:
-                sys.path.insert(1, script_dir)
-            script_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-            if os.path.isdir(script_dir) and script_dir not in sys.path:
-                sys.path.insert(1, script_dir)
-        #print('sys.path', sys.path)
+        import phangsPipeline
+        self.current_dir = os.getcwd()
+        self.module_dir = os.path.dirname(os.path.abspath(phangsPipeline.__path__[0]))
+        self.working_dir = os.path.join(self.module_dir, 'phangsPipelineTests')
+        self.test_data_dir = os.path.join(self.working_dir, 'test_data')
+        self.test_keys_dir = os.path.join(self.working_dir, 'test_keys')
+        self.test_sd_file = os.path.join(self.test_data_dir, 'feathering', 'ALMA_TP.NGC1808.CO21_5kmsres.image.fits')
+        self.test_interf_file = os.path.join(self.test_data_dir, 'feathering', 'ngc1808_12m+7m_co21_pbcorr_trimmed_k.fits')
     
     def import_test_image(self, filename, outname, overwrite = True):
         from phangsPipeline import casaStuff
@@ -67,113 +53,110 @@ class TestingCasaFeatherRoutines(unittest.TestCase):
         casaStuff.importfits(filename, outname)
         self.assertTrue(os.path.isdir(outname))
     
-    def fetch_test_data(self):
-        import ssl
-        import urllib.request
-        import tarfile
-        import numpy as np
-        try:
-            from astropy.io import fits
-        except:
-            import pyfits as fits
+    # def fetch_test_data(self):
+    #     import ssl
+    #     import urllib.request
+    #     import tarfile
+    #     import numpy as np
+    #     try:
+    #         from astropy.io import fits
+    #     except:
+    #         import pyfits as fits
         
-        self.test_sd_file = self.test_data_dir+os.sep+'ALMA_TP.NGC1808.CO21_5kmsres.image.fits'
-        self.test_interf_file = self.test_data_dir+os.sep+'ngc1808_12m+7m_co21_pbcorr_trimmed_k.fits'
+    #     self.test_sd_file = self.test_data_dir+os.sep+'ALMA_TP.NGC1808.CO21_5kmsres.image.fits'
+    #     self.test_interf_file = self.test_data_dir+os.sep+'ngc1808_12m+7m_co21_pbcorr_trimmed_k.fits'
         
-        use_M100 = False
-        if use_M100:
-            self.test_sd_file = self.test_data_dir+os.sep+'M100_Band3_ACA_ReferenceImages/M100_TP_CO_cube.bl.image.fits'
-            self.test_interf_file = self.test_data_dir+os.sep+'M100_Band3_ACA_ReferenceImages/M100_7m_CO.image.fits'
-            
-            if not os.path.isfile(self.test_sd_file) and \
-               not os.path.isfile(self.test_interf_file):
-                
-                if not os.path.isdir(self.test_data_dir):
-                    os.makedirs(self.test_data_dir)
-                if not os.path.isfile(self.test_data_dir+os.sep+'M100_Band3_ACA_ReferenceImages.tgz'):
-                    with urllib.request.urlopen(
-                        'https://almascience.eso.org/almadata/sciver/M100Band3ACA/M100_Band3_ACA_ReferenceImages.tgz',
-                        context = ssl._create_unverified_context()
-                        ) as fp_from, open(
-                        self.test_data_dir+os.sep+'M100_Band3_ACA_ReferenceImages.tgz', 'wb'
-                        ) as fp_to:
-                        fp_to.write(fp_from.read())
-                
-                self.assertTrue(os.path.isfile(self.test_data_dir+os.sep+'M100_Band3_ACA_ReferenceImages.tgz'))
-                
-                with tarfile.open(self.test_data_dir+os.sep+'M100_Band3_ACA_ReferenceImages.tgz', 'r:gz') as tgz:
-                    #tgz.extract(
-                    #    'M100_Band3_ACA_ReferenceImages/M100_TP_CO_cube.bl.image.fits', 
-                    #    self.test_data_dir
-                    #    )
-                    #tgz.extract(
-                    #    'M100_Band3_ACA_ReferenceImages/M100_7m_CO.image.fits', 
-                    #    self.test_data_dir
-                    #    )
-                    tgz.extractall(
-                        self.test_data_dir, 
-                        members=[
-                            tgz.getmember('M100_Band3_ACA_ReferenceImages/M100_TP_CO_cube.bl.image.fits'), 
-                            tgz.getmember('M100_Band3_ACA_ReferenceImages/M100_7m_CO.image.fits')
-                            ],
-                        )
+    #     # use_M100 = False
+    #     # if use_M100:
+    #     #     self.test_sd_file = self.test_data_dir+os.sep+'M100_Band3_ACA_ReferenceImages/M100_TP_CO_cube.bl.image.fits'
+    #     #     self.test_interf_file = self.test_data_dir+os.sep+'M100_Band3_ACA_ReferenceImages/M100_7m_CO.image.fits'
+    #     # 
+    #     #     if not os.path.isfile(self.test_sd_file) and \
+    #     #        not os.path.isfile(self.test_interf_file):
+    #     # 
+    #     #         if not os.path.isdir(self.test_data_dir):
+    #     #             os.makedirs(self.test_data_dir)
+    #     #         if not os.path.isfile(self.test_data_dir+os.sep+'M100_Band3_ACA_ReferenceImages.tgz'):
+    #     #             with urllib.request.urlopen(
+    #     #                 'https://almascience.eso.org/almadata/sciver/M100Band3ACA/M100_Band3_ACA_ReferenceImages.tgz',
+    #     #                 context = ssl._create_unverified_context()
+    #     #                 ) as fp_from, open(
+    #     #                 self.test_data_dir+os.sep+'M100_Band3_ACA_ReferenceImages.tgz', 'wb'
+    #     #                 ) as fp_to:
+    #     #                 fp_to.write(fp_from.read())
+    #     # 
+    #     #         self.assertTrue(os.path.isfile(self.test_data_dir+os.sep+'M100_Band3_ACA_ReferenceImages.tgz'))
+    #     # 
+    #     #         with tarfile.open(self.test_data_dir+os.sep+'M100_Band3_ACA_ReferenceImages.tgz', 'r:gz') as tgz:
+    #     #             #tgz.extract(
+    #     #             #    'M100_Band3_ACA_ReferenceImages/M100_TP_CO_cube.bl.image.fits', 
+    #     #             #    self.test_data_dir
+    #     #             #    )
+    #     #             #tgz.extract(
+    #     #             #    'M100_Band3_ACA_ReferenceImages/M100_7m_CO.image.fits', 
+    #     #             #    self.test_data_dir
+    #     #             #    )
+    #     #             tgz.extractall(
+    #     #                 self.test_data_dir, 
+    #     #                 members=[
+    #     #                     tgz.getmember('M100_Band3_ACA_ReferenceImages/M100_TP_CO_cube.bl.image.fits'), 
+    #     #                     tgz.getmember('M100_Band3_ACA_ReferenceImages/M100_7m_CO.image.fits')
+    #     #                     ],
+    #     #                 )
         
-        if not os.path.isfile(self.test_sd_file):
-            print('Error! Test data file is not found: '+os.path.isfile(self.test_sd_file))
-        if not os.path.isfile(self.test_interf_file):
-            print('Error! Test data file is not found: '+os.path.isfile(self.test_interf_file))
-        self.assertTrue(os.path.isfile(self.test_sd_file))
-        self.assertTrue(os.path.isfile(self.test_interf_file))
+    #     if not os.path.isfile(self.test_sd_file):
+    #         print('Error! Test data file is not found: '+os.path.isfile(self.test_sd_file))
+    #     if not os.path.isfile(self.test_interf_file):
+    #         print('Error! Test data file is not found: '+os.path.isfile(self.test_interf_file))
+    #     self.assertTrue(os.path.isfile(self.test_sd_file))
+    #     self.assertTrue(os.path.isfile(self.test_interf_file))
     
     def test_prep_sd_for_feather(self):
-        self.set_sys_path()
-        self.fetch_test_data()
         from phangsPipeline import casaFeatherRoutines as cfr
+        assert os.path.exists(self.test_sd_file), 'Testing data not found: '+self.test_sd_file
+        assert os.path.exists(self.test_interf_file), 'Testing data not found: '+self.test_interf_file
         if self.test_interf_file.endswith('.fits'):
             self.import_test_image(
                 self.test_interf_file, 
-                self.test_data_dir+os.sep+'interf_data_to_feather.image.tmp', 
+                self.test_data_dir+os.sep+'interf_data_to_feather.image', 
                 )
         else:
             shutil.copy2(
                 self.test_interf_file, 
-                self.test_data_dir+os.sep+'interf_data_to_feather.image.tmp', 
+                self.test_data_dir+os.sep+'interf_data_to_feather.image', 
                 )
         from casatasks import imhead
-        if imhead(self.test_data_dir+os.sep+'interf_data_to_feather.image.tmp')['ndim'] == 3:
+        if imhead(self.test_data_dir+os.sep+'interf_data_to_feather.image')['ndim'] == 3:
             do_dropdeg = True
         else:
             do_dropdeg = False
         cfr.prep_sd_for_feather(
                 sdfile_in=self.test_sd_file,
-                sdfile_out=self.test_data_dir+os.sep+'sd_data_to_feather.image.tmp',
-                interf_file=self.test_data_dir+os.sep+'interf_data_to_feather.image.tmp',
+                sdfile_out=self.test_data_dir+os.sep+'sd_data_to_feather.image',
+                interf_file=self.test_data_dir+os.sep+'interf_data_to_feather.image',
                 do_dropdeg=do_dropdeg,
                 overwrite=True,
             )
     
     def test_feather_two_cubes(self):
-        self.set_sys_path()
-        self.fetch_test_data()
         from phangsPipeline import casaFeatherRoutines as cfr
         self.test_prep_sd_for_feather()
         cfr.feather_two_cubes(
-                interf_file=self.test_data_dir+os.sep+'interf_data_to_feather.image.tmp',
-                sd_file=self.test_data_dir+os.sep+'sd_data_to_feather.image.tmp',
-                out_file=self.test_data_dir+os.sep+'feathered.image.tmp',
+                interf_file=self.test_data_dir+os.sep+'interf_data_to_feather.image',
+                sd_file=self.test_data_dir+os.sep+'sd_data_to_feather.image',
+                out_file=self.test_data_dir+os.sep+'feathered.image',
                 do_blank=True,
                 do_apodize=False,
                 overwrite=True,
             )
         
     def tearDown(self):
-        #pass
-        if os.path.exists(self.test_data_dir+os.sep+'sd_data_to_feather.image.tmp'):
-           shutil.rmtree(self.test_data_dir+os.sep+'sd_data_to_feather.image.tmp')
-        if os.path.exists(self.test_data_dir+os.sep+'interf_data_to_feather.image.tmp'):
-           shutil.rmtree(self.test_data_dir+os.sep+'interf_data_to_feather.image.tmp')
-        if os.path.exists(self.test_data_dir+os.sep+'feathered.image.tmp'):
-           shutil.rmtree(self.test_data_dir+os.sep+'feathered.image.tmp')
+        if os.path.exists(self.test_data_dir+os.sep+'sd_data_to_feather.image'):
+           shutil.rmtree(self.test_data_dir+os.sep+'sd_data_to_feather.image')
+        if os.path.exists(self.test_data_dir+os.sep+'interf_data_to_feather.image'):
+           shutil.rmtree(self.test_data_dir+os.sep+'interf_data_to_feather.image')
+        if os.path.exists(self.test_data_dir+os.sep+'feathered.image'):
+           shutil.rmtree(self.test_data_dir+os.sep+'feathered.image')
 
 
 
@@ -184,19 +167,11 @@ class TestingCasaFeatherRoutinesInCasa():
         pass
     
     def suite(self=None):
-        #modules = (
-        #    'TestingCasaFeatherRoutines',
-        #)
         testsuite = unittest.TestSuite()
-        #for module in map(__import__, modules):
-        #    testsuite.addTest(unittest.findTestCases(module))
         testsuite.addTest(unittest.makeSuite(TestingCasaFeatherRoutines))
         return testsuite
     
     def run(self):
-        #del sys.modules['phangsPipelineTests']
-        #del sys.modules['phangsPipelineTests.test_CasaFeatherRoutines']
-        #import phangsPipelineTests; phangsPipelineTests.TestingCasaFeatherRoutinesInCasa().run() 
         unittest.main(defaultTest='phangsPipelineTests.TestingCasaFeatherRoutinesInCasa.suite', exit=False)
 
 

--- a/phangsPipelineTests/test_handlerImaging.py
+++ b/phangsPipelineTests/test_handlerImaging.py
@@ -44,30 +44,30 @@ class TestingHandlerImaging(unittest.TestCase):
     
     def setup_necessary_directories(self):
         for this_dir in ['uvdata', 'singledish']: 
-            assert os.path.isdir(self.test_data_dir+os.sep+this_dir)
+            assert os.path.isdir(self.test_data_dir+os.sep+this_dir), 'Testing data not found: '+self.test_data_dir+os.sep+this_dir
         for this_dir in ['cleanmasks', 'reduction']: 
             if not os.path.isdir(self.test_data_dir+os.sep+this_dir):
                 os.makedirs(self.test_data_dir+os.sep+this_dir)
     
-    def test_task_initialize_clean_call(self):
-        import phangsPipeline
-        from phangsPipeline import handlerKeys as kh
-        from phangsPipeline import handlerImaging as imh
-        os.chdir(self.working_dir)
-        self.setup_necessary_directories()
-        this_kh = kh.KeyHandler(master_key=self.test_keys_dir+os.sep+'master_key.txt')
-        this_imh = imh.ImagingHandler(key_handler=this_kh)
-        os.chdir(os.path.join(self.test_data_dir, 'reduction', 'imaging', 'ngc4321'))
-        clean_call = this_imh.task_initialize_clean_call(
-            target='ngc4321', config='7m', product='co10',
-            )
-        #print('clean_call', clean_call)
-        cell, imsize = this_imh.task_pick_cell_and_imsize(
-            clean_call=clean_call,
-            check_overrides=True,
-            target='ngc4321', config='7m', product='co10',
-            )
-        os.chdir(self.current_dir)
+    # def test_task_initialize_clean_call(self):
+    #     import phangsPipeline
+    #     from phangsPipeline import handlerKeys as kh
+    #     from phangsPipeline import handlerImaging as imh
+    #     os.chdir(self.working_dir)
+    #     self.setup_necessary_directories()
+    #     this_kh = kh.KeyHandler(master_key=self.test_keys_dir+os.sep+'master_key.txt')
+    #     this_imh = imh.ImagingHandler(key_handler=this_kh)
+    #     os.chdir(os.path.join(self.test_data_dir, 'reduction', 'imaging', 'ngc4321'))
+    #     clean_call = this_imh.task_initialize_clean_call(
+    #         target='ngc4321', config='7m', product='co10',
+    #         )
+    #     #print('clean_call', clean_call)
+    #     cell, imsize = this_imh.task_pick_cell_and_imsize(
+    #         clean_call=clean_call,
+    #         check_overrides=True,
+    #         target='ngc4321', config='7m', product='co10',
+    #         )
+    #     os.chdir(self.current_dir)
     
     def test_loop_imaging(self):
         import phangsPipeline
@@ -84,9 +84,9 @@ class TestingHandlerImaging(unittest.TestCase):
     
     def tearDown(self):
         os.chdir(self.current_dir)
-        for this_dir in ['cleanmasks', 'reduction']: 
-            if os.path.isdir(self.test_data_dir+os.sep+this_dir):
-                shutil.rmtree(self.test_data_dir+os.sep+this_dir)
+        #for this_dir in ['cleanmasks', 'reduction']: 
+        #    if os.path.isdir(self.test_data_dir+os.sep+this_dir):
+        #        shutil.rmtree(self.test_data_dir+os.sep+this_dir)
 
 
 

--- a/phangsPipelineTests/test_handlerImaging.py
+++ b/phangsPipelineTests/test_handlerImaging.py
@@ -1,0 +1,112 @@
+"""
+How to run this test inside CASA:
+
+```
+sys.path.append('../casa_analysis_scripts')
+sys.path.append('../analysis_scripts')
+sys.path.append('.')
+import importlib
+#importlib.reload = reload
+import phangsPipeline
+importlib.reload(phangsPipeline)
+importlib.reload(phangsPipeline.handlerKeys)
+importlib.reload(phangsPipeline.handlerImaging)
+importlib.reload(phangsPipeline.casaImagingRoutines)
+import phangsPipelineTests
+importlib.reload(phangsPipelineTests)
+importlib.reload(phangsPipelineTests.test_handlerImaging)
+phangsPipelineTests.TestingHandlerImagingInCasa().run()
+```
+
+What will be tested:
+
+```
+prep_sd_for_feather
+
+```
+"""
+
+import os, sys, shutil
+import unittest
+
+
+class TestingHandlerImaging(unittest.TestCase):
+    """docstring for TestingHandlerImaging"""
+    
+    def __init__(self, *args, **kwargs):
+        super(TestingHandlerImaging, self).__init__(*args, **kwargs)
+        import phangsPipeline
+        self.current_dir = os.getcwd()
+        self.module_dir = os.path.dirname(os.path.abspath(phangsPipeline.__path__[0]))
+        self.working_dir = os.path.join(self.module_dir, 'phangsPipelineTests')
+        self.test_data_dir = os.path.join(self.working_dir, 'test_data')
+        self.test_keys_dir = os.path.join(self.working_dir, 'test_keys')
+    
+    def setup_necessary_directories(self):
+        for this_dir in ['uvdata', 'singledish']: 
+            assert os.path.isdir(self.test_data_dir+os.sep+this_dir)
+        for this_dir in ['cleanmasks', 'reduction']: 
+            if not os.path.isdir(self.test_data_dir+os.sep+this_dir):
+                os.makedirs(self.test_data_dir+os.sep+this_dir)
+    
+    def test_task_initialize_clean_call(self):
+        import phangsPipeline
+        from phangsPipeline import handlerKeys as kh
+        from phangsPipeline import handlerImaging as imh
+        os.chdir(self.working_dir)
+        self.setup_necessary_directories()
+        this_kh = kh.KeyHandler(master_key=self.test_keys_dir+os.sep+'master_key.txt')
+        this_imh = imh.ImagingHandler(key_handler=this_kh)
+        os.chdir(os.path.join(self.test_data_dir, 'reduction', 'imaging', 'ngc4321'))
+        clean_call = this_imh.task_initialize_clean_call(
+            target='ngc4321', config='7m', product='co10',
+            )
+        #print('clean_call', clean_call)
+        cell, imsize = this_imh.task_pick_cell_and_imsize(
+            clean_call=clean_call,
+            check_overrides=True,
+            target='ngc4321', config='7m', product='co10',
+            )
+        os.chdir(self.current_dir)
+    
+    def test_loop_imaging(self):
+        import phangsPipeline
+        from phangsPipeline import handlerKeys as kh
+        from phangsPipeline import handlerImaging as imh
+        os.chdir(self.working_dir)
+        self.setup_necessary_directories()
+        this_kh = kh.KeyHandler(master_key=self.test_keys_dir+os.sep+'master_key.txt')
+        this_imh = imh.ImagingHandler(key_handler=this_kh)
+        this_imh.loop_imaging(
+            do_all=True,
+            )
+        os.chdir(self.current_dir)
+    
+    def tearDown(self):
+        os.chdir(self.current_dir)
+        for this_dir in ['cleanmasks', 'reduction']: 
+            if os.path.isdir(self.test_data_dir+os.sep+this_dir):
+                shutil.rmtree(self.test_data_dir+os.sep+this_dir)
+
+
+
+class TestingHandlerImagingInCasa():
+    """docstring for TestingHandlerImagingInCasa"""
+    
+    def __init__(self):
+        pass
+    
+    def suite(self=None):
+        testsuite = unittest.TestSuite()
+        testsuite.addTest(unittest.makeSuite(TestingHandlerImaging))
+        return testsuite
+    
+    def run(self):
+        unittest.main(defaultTest='phangsPipelineTests.TestingHandlerImagingInCasa.suite', exit=False)
+
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+

--- a/phangsPipelineTests/test_handlerKeys.py
+++ b/phangsPipelineTests/test_handlerKeys.py
@@ -42,7 +42,7 @@ class TestingHandlerKeys(unittest.TestCase):
     
     def setup_necessary_directories(self):
         for this_dir in ['uvdata', 'singledish']: 
-            assert os.path.isdir(self.test_data_dir+os.sep+this_dir)
+            assert os.path.isdir(self.test_data_dir+os.sep+this_dir), 'Testing data not found: '+self.test_data_dir+os.sep+this_dir
         for this_dir in ['cleanmasks', 'reduction']: 
             if not os.path.isdir(self.test_data_dir+os.sep+this_dir):
                 os.makedirs(self.test_data_dir+os.sep+this_dir)

--- a/phangsPipelineTests/test_handlerKeys.py
+++ b/phangsPipelineTests/test_handlerKeys.py
@@ -1,0 +1,88 @@
+"""
+How to run this test inside CASA:
+
+```
+sys.path.append('../casa_analysis_scripts')
+sys.path.append('../analysis_scripts')
+sys.path.append('.')
+import importlib
+#importlib.reload = reload
+import phangsPipeline
+importlib.reload(phangsPipeline)
+importlib.reload(phangsPipeline.handlerKeys)
+import phangsPipelineTests
+importlib.reload(phangsPipelineTests)
+importlib.reload(phangsPipelineTests.test_handlerKeys)
+phangsPipelineTests.TestingHandlerKeysInCasa().run()
+```
+
+What will be tested:
+
+```
+prep_sd_for_feather
+
+```
+"""
+
+import os, sys, shutil
+import unittest
+
+
+class TestingHandlerKeys(unittest.TestCase):
+    """docstring for TestingHandlerKeys"""
+    
+    def __init__(self, *args, **kwargs):
+        super(TestingHandlerKeys, self).__init__(*args, **kwargs)
+        import phangsPipeline
+        self.current_dir = os.getcwd()
+        self.module_dir = os.path.dirname(os.path.abspath(phangsPipeline.__path__[0]))
+        self.working_dir = os.path.join(self.module_dir, 'phangsPipelineTests')
+        self.test_data_dir = os.path.join(self.working_dir, 'test_data')
+        self.test_keys_dir = os.path.join(self.working_dir, 'test_keys')
+    
+    def setup_necessary_directories(self):
+        for this_dir in ['uvdata', 'singledish']: 
+            assert os.path.isdir(self.test_data_dir+os.sep+this_dir)
+        for this_dir in ['cleanmasks', 'reduction']: 
+            if not os.path.isdir(self.test_data_dir+os.sep+this_dir):
+                os.makedirs(self.test_data_dir+os.sep+this_dir)
+    
+    def test_get_overrides(self):
+        import phangsPipeline
+        from phangsPipeline import handlerKeys as kh
+        os.chdir(self.working_dir)
+        self.setup_necessary_directories()
+        this_kh = kh.KeyHandler(master_key=self.test_keys_dir+os.sep+'master_key.txt')
+        os.chdir(self.current_dir)
+        assert ('linearmosaic_deltara' in this_kh.get_overrides('ngc3627'))
+        assert (this_kh.get_overrides('ngc3627', 'linearmosaic_deltara') == '240')
+        assert (this_kh.get_overrides('ngc3627', 'something') is None)
+        
+    def tearDown(self):
+        os.chdir(self.current_dir)
+        for this_dir in ['cleanmasks', 'reduction']: 
+            if os.path.isdir(self.test_data_dir+os.sep+this_dir):
+                shutil.rmtree(self.test_data_dir+os.sep+this_dir)
+
+
+
+class TestingHandlerKeysInCasa():
+    """docstring for TestingHandlerKeysInCasa"""
+    
+    def __init__(self):
+        pass
+    
+    def suite(self=None):
+        testsuite = unittest.TestSuite()
+        testsuite.addTest(unittest.makeSuite(TestingHandlerKeys))
+        return testsuite
+    
+    def run(self):
+        unittest.main(defaultTest='phangsPipelineTests.TestingHandlerKeysInCasa.suite', exit=False)
+
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+

--- a/phangsPipelineTests/test_handlerVis.py
+++ b/phangsPipelineTests/test_handlerVis.py
@@ -43,7 +43,7 @@ class TestingHandlerVis(unittest.TestCase):
     
     def setup_necessary_directories(self):
         for this_dir in ['uvdata', 'singledish']: 
-            assert os.path.isdir(self.test_data_dir+os.sep+this_dir)
+            assert os.path.isdir(self.test_data_dir+os.sep+this_dir), 'Testing data not found: '+self.test_data_dir+os.sep+this_dir
         for this_dir in ['cleanmasks', 'reduction']: 
             if not os.path.isdir(self.test_data_dir+os.sep+this_dir):
                 os.makedirs(self.test_data_dir+os.sep+this_dir)
@@ -64,9 +64,9 @@ class TestingHandlerVis(unittest.TestCase):
         
     def tearDown(self):
         os.chdir(self.current_dir)
-        for this_dir in ['cleanmasks', 'reduction']: 
-            if os.path.isdir(self.test_data_dir+os.sep+this_dir):
-                shutil.rmtree(self.test_data_dir+os.sep+this_dir)
+        #for this_dir in ['cleanmasks', 'reduction']: 
+        #    if os.path.isdir(self.test_data_dir+os.sep+this_dir):
+        #        shutil.rmtree(self.test_data_dir+os.sep+this_dir)
 
 
 

--- a/phangsPipelineTests/test_handlerVis.py
+++ b/phangsPipelineTests/test_handlerVis.py
@@ -1,0 +1,92 @@
+"""
+How to run this test inside CASA:
+
+```
+sys.path.append('../casa_analysis_scripts')
+sys.path.append('../analysis_scripts')
+sys.path.append('.')
+import importlib
+#importlib.reload = reload
+import phangsPipeline
+importlib.reload(phangsPipeline)
+importlib.reload(phangsPipeline.handlerKeys)
+importlib.reload(phangsPipeline.handlerVis)
+import phangsPipelineTests
+importlib.reload(phangsPipelineTests)
+importlib.reload(phangsPipelineTests.test_handlerVis)
+phangsPipelineTests.TestingHandlerVisInCasa().run()
+```
+
+What will be tested:
+
+```
+prep_sd_for_feather
+
+```
+"""
+
+import os, sys, shutil
+import unittest
+
+
+class TestingHandlerVis(unittest.TestCase):
+    """docstring for TestingHandlerVis"""
+    
+    def __init__(self, *args, **kwargs):
+        super(TestingHandlerVis, self).__init__(*args, **kwargs)
+        import phangsPipeline
+        self.current_dir = os.getcwd()
+        self.module_dir = os.path.dirname(os.path.abspath(phangsPipeline.__path__[0]))
+        self.working_dir = os.path.join(self.module_dir, 'phangsPipelineTests')
+        self.test_data_dir = os.path.join(self.working_dir, 'test_data')
+        self.test_keys_dir = os.path.join(self.working_dir, 'test_keys')
+    
+    def setup_necessary_directories(self):
+        for this_dir in ['uvdata', 'singledish']: 
+            assert os.path.isdir(self.test_data_dir+os.sep+this_dir)
+        for this_dir in ['cleanmasks', 'reduction']: 
+            if not os.path.isdir(self.test_data_dir+os.sep+this_dir):
+                os.makedirs(self.test_data_dir+os.sep+this_dir)
+    
+    def test_loop_stage_uvdata(self):
+        import phangsPipeline
+        from phangsPipeline import handlerKeys as kh
+        from phangsPipeline import handlerVis as uvh
+        os.chdir(self.working_dir)
+        self.setup_necessary_directories()
+        this_kh = kh.KeyHandler(master_key=self.test_keys_dir+os.sep+'master_key.txt')
+        this_uvh = uvh.VisHandler(key_handler=this_kh)
+        this_uvh.loop_stage_uvdata(
+            do_all=True,
+            )
+        os.chdir(self.current_dir)
+        assert os.path.isdir(os.path.join(self.test_data_dir, 'reduction', 'imaging', 'ngc4321', 'ngc4321_7m_co10.ms'))
+        
+    def tearDown(self):
+        os.chdir(self.current_dir)
+        for this_dir in ['cleanmasks', 'reduction']: 
+            if os.path.isdir(self.test_data_dir+os.sep+this_dir):
+                shutil.rmtree(self.test_data_dir+os.sep+this_dir)
+
+
+
+class TestingHandlerVisInCasa():
+    """docstring for TestingHandlerVisInCasa"""
+    
+    def __init__(self):
+        pass
+    
+    def suite(self=None):
+        testsuite = unittest.TestSuite()
+        testsuite.addTest(unittest.makeSuite(TestingHandlerVis))
+        return testsuite
+    
+    def run(self):
+        unittest.main(defaultTest='phangsPipelineTests.TestingHandlerVisInCasa.suite', exit=False)
+
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+

--- a/phangsPipelineTests/test_pipelineLogger.py
+++ b/phangsPipelineTests/test_pipelineLogger.py
@@ -17,30 +17,35 @@ import unittest
 class TestingPipelineLogger(unittest.TestCase):
     """docstring for TestingPipelineLogger"""
     
-    def set_sys_path(self):
-        if '__file__' in globals():
-            script_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-            if script_dir not in sys.path:
-                sys.path.insert(1, script_dir)
-        #print('sys.path', sys.path)
+    def __init__(self, *args, **kwargs):
+        super(TestingPipelineLogger, self).__init__(*args, **kwargs)
+        import phangsPipeline
+        self.current_dir = os.getcwd()
+        self.module_dir = os.path.dirname(os.path.abspath(phangsPipeline.__path__[0]))
+        self.working_dir = os.path.join(self.module_dir, 'phangsPipelineTests')
+        self.test_data_dir = os.path.join(self.working_dir, 'test_data')
+        self.test_log_file = os.path.join(self.working_dir, 'test_log_file.txt')
     
     def test_logfile(self):
-        self.set_sys_path()
         from phangsPipeline.pipelineLogger import PipelineLogger
-        with PipelineLogger('TestingPipelineLogger', level='DEBUG', logfile='logfile.txt') as logger:
+        with PipelineLogger('TestingPipelineLogger', level='DEBUG', logfile=self.test_log_file) as logger:
             logger.info('testing info to logfile')
             logger.warning('testing warning to logfile')
             logger.debug('testing debug to logfile')
             logger.error('testing error to logfile')
     
     def test_all(self):
-        self.set_sys_path()
         from phangsPipeline.pipelineLogger import PipelineLogger
         with PipelineLogger('TestingPipelineLogger', level='DEBUG') as logger:
             logger.info('testing info')
             logger.warning('testing warning')
             logger.debug('testing debug')
             logger.error('testing error')
+        
+    def tearDown(self):
+        if os.path.isfile(self.test_log_file):
+            os.remove(self.test_log_file)
+
 
 
 class TestingPipelineLoggerInCasa():
@@ -50,19 +55,11 @@ class TestingPipelineLoggerInCasa():
         pass
     
     def suite(self=None):
-        #modules = (
-        #    'TestingPipelineLogger',
-        #)
         testsuite = unittest.TestSuite()
-        #for module in map(__import__, modules):
-        #    testsuite.addTest(unittest.findTestCases(module))
         testsuite.addTest(unittest.makeSuite(TestingPipelineLogger))
         return testsuite
     
     def run(self):
-        #del sys.modules['phangsPipelineTests']
-        #del sys.modules['phangsPipelineTests.test_pipelineLogger']
-        #import phangsPipelineTests; phangsPipelineTests.TestingPipelineLoggerInCasa().run() 
         unittest.main(defaultTest='phangsPipelineTests.TestingPipelineLoggerInCasa.suite', exit=False)
 
 

--- a/phangsPipelineTests/test_pipelineLogger.py
+++ b/phangsPipelineTests/test_pipelineLogger.py
@@ -1,0 +1,72 @@
+"""
+How to run this test inside CASA:
+
+```
+sys.path.append('../scripts/analysis_scripts')
+sys.path.append('../scripts/phangs_imaging_scripts')
+import phangsPipelineTests
+importlib.reload(phangsPipelineTests)
+phangsPipelineTests.TestingPipelineLoggerInCasa().run()
+```
+"""
+
+import os, sys
+import unittest
+
+
+class TestingPipelineLogger(unittest.TestCase):
+    """docstring for TestingPipelineLogger"""
+    
+    def set_sys_path(self):
+        if '__file__' in globals():
+            script_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            if script_dir not in sys.path:
+                sys.path.insert(1, script_dir)
+        #print('sys.path', sys.path)
+    
+    def test_logfile(self):
+        self.set_sys_path()
+        from phangsPipeline.pipelineLogger import PipelineLogger
+        with PipelineLogger('TestingPipelineLogger', level='DEBUG', logfile='logfile.txt') as logger:
+            logger.info('testing info to logfile')
+            logger.warning('testing warning to logfile')
+            logger.debug('testing debug to logfile')
+            logger.error('testing error to logfile')
+    
+    def test_all(self):
+        self.set_sys_path()
+        from phangsPipeline.pipelineLogger import PipelineLogger
+        with PipelineLogger('TestingPipelineLogger', level='DEBUG') as logger:
+            logger.info('testing info')
+            logger.warning('testing warning')
+            logger.debug('testing debug')
+            logger.error('testing error')
+
+
+class TestingPipelineLoggerInCasa():
+    """docstring for TestingPipelineLoggerInCasa"""
+    
+    def __init__(self):
+        pass
+    
+    def suite(self=None):
+        #modules = (
+        #    'TestingPipelineLogger',
+        #)
+        testsuite = unittest.TestSuite()
+        #for module in map(__import__, modules):
+        #    testsuite.addTest(unittest.findTestCases(module))
+        testsuite.addTest(unittest.makeSuite(TestingPipelineLogger))
+        return testsuite
+    
+    def run(self):
+        #del sys.modules['phangsPipelineTests']
+        #del sys.modules['phangsPipelineTests.test_pipelineLogger']
+        #import phangsPipelineTests; phangsPipelineTests.TestingPipelineLoggerInCasa().run() 
+        unittest.main(defaultTest='phangsPipelineTests.TestingPipelineLoggerInCasa.suite', exit=False)
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+


### PR DESCRIPTION
## Bug fixing: getchunk/putchunk/putregion

Fixing a known issue when dealing with big images, e.g., 2880x2880x393, CASA `image.getchunk()`, `image.putchunk()` or `image.putregion()` breaks with the following error message:
```
2021-08-24 14:53:27     SEVERE  image::putchunk (file binding/tools/image/image_cmpt.cc, line 4354)     Exception Reported: ArrayBase::reform() - total elements differ
```
Our code uses these `getchunk`, `putchunk` and `putregion` commands in `casaCubeRoutines.get_mask`, `casaCubeRoutines.copy_mask`, `casaCubeRoutines.multiply_cube_by_value`, and `casaFeatherRoutines.feather_two_cubes` functions. Therefore, the processing are affected. 

This issue is noticed by us as early as August, 2021 when dealing with high-resolution observations but still with the huge linear mosaic area set by the "keys/overrides.txt" file (forgot to disable it). 
This issue is also noted in [https://casa.nrao.edu/docs/casaref/image.putchunk.html](https://casa.nrao.edu/docs/casaref/image.putchunk.html) as: "_If all the pixels didn’t easily fit in memory, you would iterate through the image chunk by chunk to avoid exhausting virtual memory._"

Therefore, following Eric K's brilliant suggestion #220 , now I made several fixes in "casaCubeRoutines.py" and "casaFeatherRoutines.py". The code first detects if there could be a memory issue by either checking the image size (>=2880x2880x393) or by trying to call `getchunk`. In the case of a memory issue, `getchunk` will return a flattened array instead of an array with the dimensions equaling the image cube. In this way, we set a `no_memory_issue` variable to indicate if it is okay to directly call `putchunk` and `putregion` later, or to use a workaround method. The workaround is iterating the processing channel by channel by specifying the `blc`, `trc` or `region` arguments. 

The new postprocessing part of the code has been tested to be working. 


---

## A better logging module, and testing scripts?

In addition, I am thinking about two improvements: a better logging module that can write to casalog instead of just printing on the screen if in CASA; and some testing scripts. 

I have implemented such a logging module, in "pipelineLogger.py". It aims to replace the existing "phangsLogger.py". It is an override of the `logging.getLoggerClass()` class. Inside its `debug`, `info`, `warning` and `error` functions, it first detects if `casaStuff.casalog` exists, if so, then use `casalog.post()` function to do the logging. If it detects no CASA environment, then simply does what logging.Logger does. Besides, it can log to file as mentioned in Issue #206 .

I have also prepared two preliminary testing scripts, one for the "casaCubeRoutines" and one for the "pipelineLogger". Because our pipeline works in both non-CASA and CASA environments, the testing script should do so as well. To run the `unittest` inside CASA, see the comments at the beginning of these testing scripts. I have run them to verify that my above bug fixing code works. I have tested them under both CASA 5.4.0 and 6.1.1. 


---

## Importing issues, now using try-catch as a workaround

There are also some importing issues in "taskSDintImaging.py":
```
from casatasks.private.cleanhelper import write_tclean_history, get_func_params
```
and in "phangsPipeline/__init__.py":
```
from .handlerAlmaDownload import AlmaDownloadHandler
```
for which I simply use a try-catch workaround. 
I'm not sure how well they are tested before. I would suggest to make some testing scripts to verify if they are working as expected. 


---

## Full testing still on-going

The new pieces of code are also being fully tested end-to-end on the high-res data (image-postprocessing-derived). The full processing has not finished yet, but I'd like to first prepare this PR for review. We can merge a few days later when the full processing is done. 

