### PR TITLE
Allow setting fixed frequency ranges to avoid in uvcontsub

### DIFF
--- a/phangs-alma_keys/config_definitions.txt
+++ b/phangs-alma_keys/config_definitions.txt
@@ -6,14 +6,14 @@
 # "configurations" that to be processed and combined by the
 # pipeline. Here, the user provides detailed parameters for each
 # product and config. The file has three columns:
- 
+
 # Column 1: type of field (see below)
 
 # Column 2: name (this can be anything, it will appear in file names
 # and be used by the handlers and keys)
 
 # Column 3: parameters (write as literal dictionaries with no spaces)
- 
+
 # ------------------------------------------------------------------------
 # Column 1 : "type of field"
 # ------------------------------------------------------------------------
@@ -69,6 +69,12 @@
 # cubes in units of km/s. Depending on the chosen regridding algorithm
 # this may be the exact channel width or an approximate target.
 
+# 'exclude_freq_ranges_ghz': given as a list of list, this gives a set
+# [low, high] frequency range in GHz to avoid when using uvcontsub.
+# e.g. 'exclude_freq_ranges_ghz':[[1.40,1.42]].
+# This is useful when multiple targets emit in the same transition along
+# a line-of-sight (e.g., Galactic and extragalactic 21-cm HI).
+
 # ------------------------------------------------------------------------
 # cont_product : a continuum data product
 # ------------------------------------------------------------------------
@@ -94,7 +100,7 @@
 # can be anything, e.g., 'BCD' or '12m+7m'.
 
 # These parameters need to be included:
- 
+
 # 'array_tags' : defines a list of "array_tag"s to be concatenated
 # into this config. These array tags are assigned to each measurement
 # set in the "ms_file_key.txt", which lists the visibility data. Thus,
@@ -104,7 +110,7 @@
 # "12mext"). This is fundamentally up to the user to decide. Despite
 # the names used by PHANGS-ALMA (12m, 7m) the pipeline does NOT
 # attempt to detect and assign data to arrays on its own.
- 
+
 # 'clean_scales_arcsec' : These are the scales used for multiscale
 # cleaning of data from this array. The units are arcseconds.
 
@@ -117,7 +123,7 @@
 # anything, e.g., 'BCD+tp' or '12m+7m+tp'.
 
 # These parameters need to be included:
- 
+
 # 'interf_config' : each feather config needs to map back to an
 # interferometric config. This mapping is used to carry out the
 # feathering process. This field defines the interf_config

--- a/phangsPipeline/casaCubeRoutines.py
+++ b/phangsPipeline/casaCubeRoutines.py
@@ -335,7 +335,9 @@ def trim_cube(
 
     myia = au.createCasaTool(casaStuff.iatool)
     myia.open(outfile + '.temp')
-    myia.adddegaxes(outfile=outfile + '.temp_deg', stokes='I', overwrite=True)
+    os.system('rm -rf '+outfile + '.temp_deg')
+    deg_im = myia.adddegaxes(outfile=outfile + '.temp_deg', stokes='I', overwrite=True)
+    deg_im.done()
     myia.close()
 
     mask = get_mask(outfile, huge_cube_workaround=True)

--- a/phangsPipeline/casaStuff.py
+++ b/phangsPipeline/casaStuff.py
@@ -26,6 +26,16 @@ try:
     from tclean import tclean
     from uvcontsub import uvcontsub
     from visstat import visstat
+    from importasdm import importasdm
+    from listobs import listobs
+    from flagcmd import flagcmd
+    from gencal import gencal
+    from sdcal import sdcal
+    from sdbaseline import sdbaseline
+    from sdimaging import sdimaging
+
+    from recipes.almahelpers import tsysspwmap
+
 
     # Version
 
@@ -66,8 +76,19 @@ except (ImportError, ModuleNotFoundError):
                            statwt,
                            tclean,
                            uvcontsub,
-                           visstat)
+                           visstat,
+                           importasdm,
+                           listobs,
+                           flagcmd,
+                           gencal,
+                           sdcal,
+                           sdbaseline,
+                           sdimaging,
+                           tsdimaging)
+
     from casatasks.private import sdint_helper
+
+    from recipes.almahelpers import tsysspwmap
 
     from .taskSDIntImaging import sdintimaging
 

--- a/phangsPipeline/handlerKeys.py
+++ b/phangsPipeline/handlerKeys.py
@@ -1808,6 +1808,27 @@ class KeyHandler:
 
         return statwt_edge
 
+    def get_contsub_excludefreqrange(self, product=None):
+        """
+        Get the frequency range to force excluding for continuum subtraction for a line product.
+        """
+
+        if product is None:
+            logging.error("Please specify a product.")
+            raise Exception("Please specify a product.")
+            return None
+
+        exclude_freq_ranges_ghz = None
+        if 'line_product' in self._config_dict:
+            if product in self._config_dict['line_product']:
+                if 'exclude_freq_ranges_ghz' in self._config_dict['line_product'][product]:
+                    exclude_freq_ranges_ghz = self._config_dict['line_product'][product]['exclude_freq_ranges_ghz']
+
+        if exclude_freq_ranges_ghz is None:
+            logging.info('No exclude_freq_ranges_ghz found for ' + product + ' .')
+
+        return exclude_freq_ranges_ghz
+
     def get_contsub_fitorder(self, product=None):
         """
         Get the fitorder to be used for continuum subtraction for a line product.

--- a/phangsPipeline/handlerVis.py
+++ b/phangsPipeline/handlerVis.py
@@ -646,6 +646,9 @@ class VisHandler(handlerTemplate.HandlerTemplate):
                 # Does it extend the upper side?
                 elif existfreq_low <= freq_low and existfreq_high <= freq_high:
                     distinct_ranges.append([existfreq_low, freq_high])
+                # Does it completely enclose the range?
+                elif existfreq_low >= freq_low and existfreq_high <= freq_high:
+                    distinct_ranges.append([freq_low, freq_high])
 
             # Reduce the range list to unique ranges.
             ranges_to_exclude = list(set([tuple(this_range) for this_range in distinct_ranges]))

--- a/phangsPipeline/scMaskingRoutines.py
+++ b/phangsPipeline/scMaskingRoutines.py
@@ -350,7 +350,7 @@ def cprops_mask(data, noise=None,
 def mask_around_value(cube, target=None, delta=None):
     """General function to make a mask that includes only values within
     delta of some target value or cube.
-    
+
     Parameters:
 
     -----------
@@ -388,13 +388,13 @@ def make_vfield_mask(cube, vfield, window,
                      outfile=None, overwrite=True):
     """Make a mask that includes only pixels within +/- some velocity
     window of a provided velocity field, which can be two-d or one-d.
-    
+
     Parameters:
 
     -----------
 
     data : string or SpectralCube
-        
+
         The original data cube.
 
     vfield : float or two-d array or string
@@ -413,7 +413,7 @@ def make_vfield_mask(cube, vfield, window,
     TBD
 
     """
-    
+
     # -------------------------------------------------
     # Get spectral information from the cube
     # -------------------------------------------------
@@ -431,19 +431,19 @@ def make_vfield_mask(cube, vfield, window,
     if type(vfield) != u.quantity.Quantity:
         # Guess matched units
         vfield = u.quantity.Quantity(vfield,spunit)
-    
+
     # Just convert if it's a scalar
     if np.ndim(vfield.data) <= 1:
         vfield = vfield.to(spunit)
         vfield = u.quantity.Quantity(np.ones((ny, nx))*vfield.value, vfield.unit)
     else:
         # reproject if it's a projection
-        if type(vfield) is Projection:            
+        if type(vfield) is Projection:
             vfield = convert_and_reproject(vfield, template=cube.header, unit=spunit)
-        else:            
+        else:
             vfield = vfield.to(spunit)
 
-    # Check sizes    
+    # Check sizes
     if (cube.shape[1] != vfield.shape[0]) or (cube.shape[2] != vfield.shape[1]):
         return(np.nan)
 
@@ -455,27 +455,27 @@ def make_vfield_mask(cube, vfield, window,
     if type(window) != u.quantity.Quantity:
         # Guess matched units
         window = u.quantity.Quantity(window,spunit)
-    
+
     # Just convert if it's a scalar
     if np.ndim(window.data) <= 1:
-        window = window.to(spunit)        
+        window = window.to(spunit)
         window = u.quantity.Quantity(np.ones((ny, nx))*window.value, window.unit)
     else:
         # reproject if it's a projection
-        if type(window) is Projection:            
+        if type(window) is Projection:
             window = convert_and_reproject(window, template=cube.header, unit=spunit)
-        else:            
+        else:
             window = window.to(spunit)
 
     # Check sizes
     if (cube.shape[1] != window.shape[0]) or (cube.shape[2] != window.shape[1]):
-        return(np.nan)    
+        return(np.nan)
 
     # -------------------------------------------------
     # Generate a velocity cube and a vfield cube
     # -------------------------------------------------
 
-    spaxis_cube = np.ones((ny, nx))[None,:,:] * spvalue[:,None,None]    
+    spaxis_cube = np.ones((ny, nx))[None,:,:] * spvalue[:,None,None]
     vfield_cube = (vfield.value)[None,:,:] * np.ones(nz)[:,None,None]
     window_cube = (window.value)[None,:,:] * np.ones(nz)[:,None,None]
 
@@ -491,13 +491,13 @@ def make_vfield_mask(cube, vfield, window,
     # -------------------------------------------------
     # Write to disk
     # -------------------------------------------------
-    
+
     mask = SpectralCube(mask.astype(np.int), wcs=cube.wcs,
                         header=cube.header,
                         meta={'BUNIT': ' ', 'BTYPE': 'Mask'})
-    
+
     # Write to disk, if desired
-    if outfile is not None:        
+    if outfile is not None:
         header = mask.header
         header['DATAMAX'] = 1
         header['DATAMIN'] = 0
@@ -507,7 +507,7 @@ def make_vfield_mask(cube, vfield, window,
 
     return(mask)
 
-def join_masks(orig_mask_in, new_mask_in, 
+def join_masks(orig_mask_in, new_mask_in,
                order='bilinear', operation='or',
                outfile=None,
                thresh=0.5,

--- a/phangsPipeline/statsHandler.py
+++ b/phangsPipeline/statsHandler.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#
+# 
 """
 This "statsHandler" is a PHANGS-ALMA internal-use object and not
 intended as a general part of the pipeline. It uses the general
@@ -35,7 +35,7 @@ class StatsHandler(handlerTemplate.HandlerTemplate):
     """
     Make handler for statistics.
     """
-
+    
     ############
     # __init__ #
     ############
@@ -45,14 +45,14 @@ class StatsHandler(handlerTemplate.HandlerTemplate):
         key_handler = None,
         dry_run = False,
         ):
-
+        
         # inherit template class
-        handlerTemplate.HandlerTemplate.__init__(self,
-                                                 key_handler = key_handler,
+        handlerTemplate.HandlerTemplate.__init__(self, 
+                                                 key_handler = key_handler, 
                                                  dry_run = dry_run)
-
+    
     def go(
-        self,
+        self, 
         outfile_singlescale='stats_singlesale.json',
         outfile_multiscale='stats_multiscale.json',
         ):
@@ -62,26 +62,26 @@ class StatsHandler(handlerTemplate.HandlerTemplate):
         ss_dict = {}
         for this_target, this_product, this_config in \
             self.looper(do_targets=True, do_products=True, do_configs=True, just_interf=True):
-            #
+            # 
             this_ms_dict = self.recipe_residual_regression(
-                target=this_target,
-                product=this_product,
+                target=this_target, 
+                product=this_product, 
                 config=this_config,
-                casaext='_multiscale',
+                casaext='_multiscale', 
                 )
             if this_ms_dict is not None:
                 ms_dict[this_ms_dict['cubename']] = this_ms_dict
 
-            #
+            # 
             this_ss_dict = self.recipe_residual_regression(
-                target=this_target,
-                product=this_product,
+                target=this_target, 
+                product=this_product, 
                 config=this_config,
-                casaext='_singlescale',
+                casaext='_singlescale', 
                 )
             if this_ss_dict is not None:
                 ss_dict[this_ss_dict['cubename']] = this_ss_dict
-
+    
         # Convert to a table and write to disk
         with open('stats_multiscale.json', 'w') as fout:
             json.dump(ms_dict , fout)
@@ -98,8 +98,8 @@ class StatsHandler(handlerTemplate.HandlerTemplate):
 
     def _fname_dict(
         self,
-        product,
-        imagename,
+        product, 
+        imagename, 
         ):
         """define file name dict for analysis in this code.
         """
@@ -130,14 +130,14 @@ class StatsHandler(handlerTemplate.HandlerTemplate):
             fname_dict['alpha'] = imagename+'.alpha'
             fname_dict['beta'] = imagename+'.beta'
         return fname_dict
-
-
+    
+    
     def recipe_residual_regression(
         self,
-        target=None,
-        product=None,
-        config=None,
-        casaext='',
+        target=None, 
+        product=None, 
+        config=None, 
+        casaext='', 
         ):
         """recipe to make clean residual regression for one target.
         """
@@ -147,37 +147,37 @@ class StatsHandler(handlerTemplate.HandlerTemplate):
             raise Exception('Please input a product!')
         if config is None:
             raise Exception('Please input a config!')
-        #
+        # 
         logger.info('------------------------------------------------------------')
         logger.info('Processing target %s product %s config %s'%(target, product, config))
         logger.info('------------------------------------------------------------')
-        #
+        # 
         image_root = utilsFilenames.get_cube_filename(\
             target=target, product=product, config=config,
             ext=None, casa=True, casaext=casaext)
-        #
+        # 
         fname_dict = self._fname_dict(\
-            product = product,
+            product = product, 
             imagename = image_root)
-        #
+        # 
         image_file = fname_dict['image']
         residual_file = fname_dict['residual']
         mask_file = fname_dict['mask']
-        #
+        # 
         target_whole_name = self._kh.get_mosaic_target_for_parts(target)
         if target_whole_name is None:
             target_whole_name = target
-        #
+        # 
         imaging_dir = self._kh.get_imaging_dir_for_target(target_whole_name, changeto=False)
-        #
+        # 
         image_file = os.path.join(imaging_dir, image_file)
         residual_file = os.path.join(imaging_dir, residual_file)
         mask_file = os.path.join(imaging_dir, mask_file)
-        #
+        # 
 
         stat_dict = self.task_residual_regression(
-            image_file=image_file,
-            residual_file=residual_file,
+            image_file=image_file, 
+            residual_file=residual_file, 
             mask_file=mask_file)
         if stat_dict is None:
             return(stat_dict)
@@ -189,29 +189,29 @@ class StatsHandler(handlerTemplate.HandlerTemplate):
         return(stat_dict)
 
     def task_residual_regression(
-        self,
-        image_file,
-        residual_file,
-        mask_file,
+        self, 
+        image_file, 
+        residual_file, 
+        mask_file, 
         ):
         """calculates the clean residual statistics
         """
         logger.info('image    : %r'%(image_file))
         logger.info('residual : %r'%(residual_file))
         logger.info('mask     : %r'%(mask_file))
-
+        
         stat_dict = cir.calc_residual_statistics(
             resid_name=residual_file,mask_name=mask_file)
 
         return(stat_dict)
-
+        
 
 
 ########
 # main #
 ########
 if __name__ == '__main__':
-
+    
     master_key = 'keys/master_key.txt'
     #master_key = '/Users/dzliu/Work/AlmaPhangs/Works/20200630_PHANGS_ALMA_clean_records/test_phangs_working_dir/keys/master_key.txt'
     if not os.path.isfile(master_key):
@@ -219,15 +219,15 @@ if __name__ == '__main__':
             master_key = raw_input("Please input your master key file path: ")
         else:
             master_key = input("Please input your master key file path: ")
-
+    
     if master_key.find("'") >= 0:
         master_key = master_key.replace("'", "")
     if master_key.find('"') >= 0:
         master_key = master_key.replace('"', '')
-
+    
     if not os.path.isfile(master_key):
         raise Exception('Error! Input master key file does not exist: %r'%(master_key))
-
+    
     this_key_handler = handlerKeys.KeyHandler(master_key = master_key)
     this_handler = StatsHandler(key_handler = this_key_handler)
     this_handler.set_line_products(only=['co21'])

--- a/phangsPipeline/utilsKeyReaders.py
+++ b/phangsPipeline/utilsKeyReaders.py
@@ -191,7 +191,7 @@ def read_ms_key(fname='', existing_dict=None, delim=None):
 
     infile = open(fname, 'r')
 
-    # Loop over the lines    
+    # Loop over the lines
     lines_read = 0
     while True:
         line = infile.readline()
@@ -275,7 +275,7 @@ def read_targetproductfile_key(fname='', existing_dict=None, delim=None):
 
     infile = open(fname, 'r')
 
-    # Loop over the lines    
+    # Loop over the lines
     lines_read = 0
     while True:
         line = infile.readline()
@@ -354,19 +354,19 @@ def read_distance_key(fname='', existing_dict=None, delim=None):
     """
     Read a distance key.
     """
-    # 
+    #
     # Initialize the dictionary
     if existing_dict is None:
         out_dict = {}
     else:
         out_dict = existing_dict
-    # 
+    #
     # Check file existence
     if not os.path.isfile(fname):
         logger.error("I tried to read key " + fname + " but it does not exist.")
         # raise Exception('Error! File not found: "'+fname+'"') #<TODO><DL># should we throw a exception
         return out_dict
-    # 
+    #
     # Read file
     logger.info("Reading: " + fname)
 
@@ -390,7 +390,7 @@ def read_distance_key(fname='', existing_dict=None, delim=None):
 
         # note that the first line of the csv is also read in. but no one will input target='galaxy' anyway.
     logger.info("Read " + str(lines_read) + " lines into a target/distance dictionary.")
-    # 
+    #
     # return out_dict
     return out_dict
 
@@ -424,7 +424,7 @@ def read_nametoname_key(fname='', existing_dict=None, delim=None, as_list=False)
 
     infile = open(fname, 'r')
 
-    # Loop over the lines    
+    # Loop over the lines
     lines_read = 0
     while True:
         line = infile.readline()
@@ -489,7 +489,7 @@ def read_target_key(fname='', existing_dict=None, delim=None):
 
     infile = open(fname, 'r')
 
-    # Loop over the lines    
+    # Loop over the lines
     lines_read = 0
     while True:
         line = infile.readline()
@@ -638,7 +638,7 @@ def read_config_key(fname='', existing_dict=None, delim=None):
     else:
         out_dict = existing_dict
 
-    # Loop over the lines    
+    # Loop over the lines
     lines_read = 0
     while True:
         line = infile.readline()
@@ -705,6 +705,7 @@ def read_config_key(fname='', existing_dict=None, delim=None):
                 'fitorder': 0,
                 'combinespw': False,
                 'lines_to_flag': [],
+                'exclude_freq_ranges_ghz': [],
             }
 
         if this_type == "cont_product":
@@ -773,7 +774,7 @@ def read_moment_key(fname='', existing_dict=None, delim=None):
 
     infile = open(fname, 'r')
 
-    # Loop over the lines    
+    # Loop over the lines
     lines_read = 0
     while True:
         line = infile.readline()
@@ -861,7 +862,7 @@ def read_override_key(fname='', existing_dict=None, delim=None):
     else:
         out_dict = existing_dict
 
-    # Loop over the lines    
+    # Loop over the lines
     lines_read = 0
     while True:
         line = infile.readline()

--- a/phangsPipeline/utilsLines.py
+++ b/phangsPipeline/utilsLines.py
@@ -65,6 +65,7 @@ line_families = {
         'h53alpha', 'h54alpha', 'h55alpha', 'h56alpha', 'h57alpha', 'h58alpha',
     ],
     'oh': ['oh1612', 'oh1665', 'oh1667', 'oh1720'],
+    'cch': ['cch10_21'],
     }
 
 # The line list dictionary
@@ -218,6 +219,7 @@ line_list = {
     'oh1665': 1.66540180,
     'oh1667': 1.66735900,
     'oh1720': 1.72052990,
+    'cch10_21': 87.31692500, # N= 1-0, J=3/2-1/2, F= 2-1
     }
 
 


### PR DESCRIPTION
Adds an additional keyword entry for line definitions in `config_definitions.txt`:  

`exclude_freq_ranges_ghz`: given as a list of list, this gives a set [low, high] frequency range in GHz to avoid when using uvcontsub.
For example:
```
line_product    hi21cm    {'line_tag':'hi21cm','channel_kms':0.42,'statwt_edge_kms':50.0}
line_product    hi21cm    {'fitorder':0,'combinespw':False,'lines_to_flag':['hi21cm'],'exclude_freq_ranges_ghz':[[1.42002671,1.42078479]]}
```

This is useful when multiple targets emit in the same transition along a line-of-sight (e.g., Galactic and extragalactic 21-cm HI). The example above sets a fixed v_rad+/-80 km/s avoidance window for Galactic HI.

This appears to working well for our current HI data, and should have no impact on other uses as the keyword is ignored when not present.

FYI @akleroy 