### PR TITLE
adjusted imports and small key reader patch

### DIFF
--- a/phangsPipeline/casaStuff.py
+++ b/phangsPipeline/casaStuff.py
@@ -1,9 +1,30 @@
 # CASA imports
-try:
-    from taskinit import *
 
-    # Import specific CASA tasks. Not all of these are used by this
-    # package, so this could be pared in the future.
+# This is a huge pain. Check that it works correctly by running
+
+# casapy-XYZ -c casaStuff.py --nologger
+
+# with XYZ each relevant version.
+
+# AKL - checked with 6.5, 6.4, 6.3, 6.2.1, 5.8, 5.7, 5.6.1, 5.4, 5.3, 5.1.1, 5.0, 4.7.2, 4.5.3
+
+# Obtain a version tuple (note the syntax change from < 6 to > 6)
+
+if ('casa' in locals()) or ('casa' in globals()):
+    # Works in CASA 4 and 5 where casa is an object
+    casa_version = tuple(map(int, casa['build']['version'].replace('-','.').split('.')[0:3])) # tested CASA 4, 5
+else:
+    # This works in CASA 6 where the casatools has a version attribute
+    casa_version = (casatools.version()[0], casatools.version()[1], casatools.version()[2])
+
+print("CASA version: ", casa_version)
+
+# Import specific CASA tasks. Not all of these are used by this
+# package, so this could be pared in the future.
+        
+if casa_version[0] < 6:
+    from taskinit import *
+    
     from concat import concat
     from exportfits import exportfits
     from feather import feather
@@ -27,19 +48,6 @@ try:
     from uvcontsub import uvcontsub
     from visstat import visstat
 
-    # version tuple
-
-    casa_version = tuple(map(int, casa['build']['version'].replace('-','.').split('.')[0:3])) # tested CASA 4, 5
-    
-    # singledish processing imports
-    
-    if casa_version < (5, 0): # for singledish processing with precasa5
-        from sdsave import sdsave
-        from sdlist import sdlist
-        from sdcal2 import sdcal2
-        from sdscale import sdscale
-        from sdplot import sdplot
-
     from importasdm import importasdm
     from listobs import listobs
     from flagcmd import flagcmd
@@ -53,16 +61,19 @@ try:
     from sdcal import sdcal
     from taskinit import msmdtool
     from taskinit import tbtool
-    from recipes.almahelpers import tsysspwmap
+        
+# imports for singledish processing when CASA version < 5
     
-    # sdintimaging imports
+if casa_version[0] < 5: 
+    from sdsave import sdsave
+    from sdlist import sdlist
+    from sdcal2 import sdcal2
+    from sdscale import sdscale
+    from sdplot import sdplot
 
-    if casa_version >= (5, 7):
-        from sdintimaging import sdintimaging
-
-except (ImportError, ModuleNotFoundError):
-
-    # This is for CASA6
+# Imports for CASA versions above 6
+    
+if casa_version[0] >= 6:
 
     import casatools
     from casatools import (table, image, imager, msmetadata, synthesisimager, synthesisutils, regionmanager)
@@ -95,7 +106,9 @@ except (ImportError, ModuleNotFoundError):
     # sdintimaging imports
     
     from casatasks.private import sdint_helper
-    from .taskSDIntImaging import sdintimaging
+
+    #from .taskSDIntImaging import sdintimaging
+    from casatasks import sdintimaging
 
     # singledish processing imports
     #   see some documents at 
@@ -111,7 +124,7 @@ except (ImportError, ModuleNotFoundError):
     from casatasks import (importasdm, listobs, flagcmd, flagdata)
 
     import almatasks
-    from almatasks.private.almahelpers import tsysspwmap
+    
     import casaplotms
     plotms = casaplotms.gotasks.plotms.plotms
     import casaviewer
@@ -123,10 +136,15 @@ except (ImportError, ModuleNotFoundError):
     sdimaging = casashell.private.sdimaging.sdimaging
     sdcal = casashell.private.sdcal.sdcal
 
-    # version tuple
+# sdintimaging import
+
+if (casa_version[0] >= 5) and (casa_version[1] >= 7):
+    from sdintimaging import sdintimaging
+
+# tsysspwmap import
     
-    casa_version = casatools.version()
-
-
-
-
+if casa_version[0] <= 5:
+    from recipes.almahelpers import tsysspwmap
+else:
+    #from almatasks.private.almahelpers import tsysspwmap
+    from almahelpers_localcopy import tsysspwmap

--- a/phangsPipeline/casaStuff.py
+++ b/phangsPipeline/casaStuff.py
@@ -10,8 +10,12 @@
 
 # Obtain a version tuple (note the syntax change from < 6 to > 6)
 
+try:
+    from taskinit import *
+except ModuleNotFoundError:
+    pass
+
 if ('casa' in locals()) or ('casa' in globals()):
-    # Works in CASA 4 and 5 where casa is an object
     casa_version = tuple(map(int, casa['build']['version'].replace('-','.').split('.')[0:3])) # tested CASA 4, 5
 else:
     # This works in CASA 6 where the casatools has a version attribute

--- a/phangsPipeline/casaStuff.py
+++ b/phangsPipeline/casaStuff.py
@@ -15,6 +15,7 @@ if ('casa' in locals()) or ('casa' in globals()):
     casa_version = tuple(map(int, casa['build']['version'].replace('-','.').split('.')[0:3])) # tested CASA 4, 5
 else:
     # This works in CASA 6 where the casatools has a version attribute
+    import casatools
     casa_version = (casatools.version()[0], casatools.version()[1], casatools.version()[2])
 
 print("CASA version: ", casa_version)

--- a/phangsPipeline/utilsKeyReaders.py
+++ b/phangsPipeline/utilsKeyReaders.py
@@ -382,11 +382,17 @@ def read_distance_key(fname='', existing_dict=None, delim=None):
         if name.strip() == 'galaxy':
             continue
         dist_mpc = t.split(delim)[1]
-        if re.match(r'^[0-9eE.+-]+$', dist_mpc):
-            out_dict[name] = {}
-            out_dict[name]['distance'] = float(dist_mpc)
-            # logger.debug('distance of '+t.split(delim)[0]+' is '+t.split(delim)[1]+' Mpc')
-            lines_read += 1
+        
+        #if re.match(r'^[0-9eE.+-]+$', dist_mpc) is not None:
+        try:
+            float(dist_mpc)
+        except ValueError:
+            continue
+
+        out_dict[name] = {}
+        out_dict[name]['distance'] = float(dist_mpc)
+        # logger.debug('distance of '+t.split(delim)[0]+' is '+t.split(delim)[1]+' Mpc')
+        lines_read += 1
 
         # note that the first line of the csv is also read in. but no one will input target='galaxy' anyway.
     logger.info("Read " + str(lines_read) + " lines into a target/distance dictionary.")


### PR DESCRIPTION
@1054 @e-koch or @low-sky 

See if this makes sense - I adjusted the imports in casaStuff and then executed it in CASA versions from 4.5 through 6.5 . I think it should now not trigger errors, import successfully and be more stable. It's a beast though.

I also made a small key reader patch for the distance key. I'm not sure what happened, but re.match might have changed across python version. It works in the new form as far as I can tell.