### PR TITLE
pip CASA updates

### DIFF
--- a/phangsPipeline/__init__.py
+++ b/phangsPipeline/__init__.py
@@ -15,11 +15,13 @@ from .handlerSingleDish import SingleDishHandler
 from .handlerVis import VisHandler
 from .handlerPostprocess import PostProcessHandler
 from .handlerDerived import DerivedHandler
+from .handlerRelease import ReleaseHandler
 
 if casa_enabled:
     from .handlerImaging import ImagingHandler
 
-__all__ = ["setup_logger", "KeyHandler", "SingleDishHandler", "VisHandler", "PostProcessHandler", "DerivedHandler"]
+__all__ = ["setup_logger", "KeyHandler", "SingleDishHandler", "VisHandler", "PostProcessHandler", "DerivedHandler",
+           "ReleaseHandler"]
 
 if casa_enabled:
     __all__.append("ImagingHandler")

--- a/phangsPipeline/__init__.py
+++ b/phangsPipeline/__init__.py
@@ -29,5 +29,5 @@ if casa_enabled:
 try:
     from .handlerAlmaDownload import AlmaDownloadHandler
     __all__.append("AlmaDownloadHandler")
-except:
+except ImportError:
     pass

--- a/phangsPipeline/casaCubeRoutines.py
+++ b/phangsPipeline/casaCubeRoutines.py
@@ -350,7 +350,7 @@ def multiply_cube_by_value(infile, value, brightness_unit, huge_cube_workaround=
     #    hdu = pyfits.open(infile + '.fits')[0]
     #    hdu.data *= value
     #
-    #    hdu.writeto(infile + '.fits', clobber=True)
+    #    hdu.writeto(infile + '.fits', overwrite=True)
     #    casaStuff.importfits(fitsimage=infile + '.fits',
     #                         imagename=infile,
     #                         overwrite=True)
@@ -516,7 +516,10 @@ def export_and_cleanup(
     hdr['COMMENT'] = 'Produced with PHANGS-ALMA pipeline version ' + pipeVer
 
     # Overwrite
-    hdu.writeto(outfile, clobber=True)
+    try:
+        hdu.writeto(outfile, clobber=True)
+    except TypeError:
+        hdu.writeto(outfile, overwrite=True)
 
     return()
 

--- a/phangsPipeline/casaCubeRoutines.py
+++ b/phangsPipeline/casaCubeRoutines.py
@@ -818,11 +818,23 @@ def align_to_target(
             logger.error("Output exists and overwrite set to false - "+outfile)
             return(False)
 
+    # If we have less than 50 (output) pixels along an axis to be regridded, we need to
+    # decrease the decimation factor
+    decimate = 10
+    input_hdr = casaStuff.imhead(infile)
+    output_hdr = casaStuff.imhead(template)
+    input_shape = input_hdr['shape']
+    output_shape = output_hdr['shape']
+    regrid_axes = np.where(input_shape != output_shape)[0]
+    if np.any(output_shape[regrid_axes] < 50):
+        decimate = 1
+
     casaStuff.imregrid(
         imagename=infile,
         template=template,
         output=outfile,
         interpolation=interpolation,
+        decimate=decimate,
         asvelocity=asvelocity,
         axes=axes,
         overwrite=True)

--- a/phangsPipeline/casaMaskingRoutines.py
+++ b/phangsPipeline/casaMaskingRoutines.py
@@ -271,7 +271,12 @@ def write_mask(infile, outfile, mask, huge_cube_workaround=True):
         for wcs_name in wcs_names:
             hdu.header[wcs_name.upper()] = header[wcs_name]
 
-        hdu.writeto(outfile + '.fits', clobber=True)
+        # Variations between pyfits and astropy
+        try:
+            hdu.writeto(outfile + '.fits', clobber=True)
+        except TypeError:
+            hdu.writeto(outfile + '.fits', overwrite=True)
+
         casaStuff.importfits(fitsimage=outfile + '.fits',
                              imagename=outfile,
                              overwrite=True)

--- a/phangsPipeline/casaMaskingRoutines.py
+++ b/phangsPipeline/casaMaskingRoutines.py
@@ -395,7 +395,7 @@ def signal_mask(
         del old_mask
 
     logger.info('Recasting as an int.')
-    # this might be better: mask.astype(np.int, copy=False)
+    # this might be better: mask.astype(int, copy=False)
     # mask = mask.astype(int)
     mask = mask.astype(np.int32)
 

--- a/phangsPipeline/casaMosaicRoutines.py
+++ b/phangsPipeline/casaMosaicRoutines.py
@@ -777,11 +777,11 @@ def generate_weight_file(
 
     if input_file is None and input_value is not None:
 
-        if input_type is 'noise':
+        if input_type == 'noise':
             weight_value = 1./input_value**2
-        if input_type is 'pb':
+        if input_type == 'pb':
             weight_value = input_value**2
-        if input_type is 'weight':
+        if input_type == 'weight':
             weight_value = input_value
 
         weight_image = data*0.0 + weight_value
@@ -791,11 +791,11 @@ def generate_weight_file(
 
     if input_file is not None:
 
-        if input_type is 'noise':
+        if input_type == 'noise':
             weight_image = 1./data**2
-        if input_type is 'pb':
+        if input_type == 'pb':
             weight_image = data**2
-        if input_type is 'weight':
+        if input_type == 'weight':
             weight_image = data
 
     # Now we have a weight image. If request, scale the data by a factor.

--- a/phangsPipeline/handlerRelease.py
+++ b/phangsPipeline/handlerRelease.py
@@ -36,7 +36,6 @@ if casa_enabled:
 else:
     logger.debug('casa_enabled = False')
 
-from . import utils
 from . import utilsResolutions
 from . import utilsFilenames
 from . import utilsLines

--- a/phangsPipeline/handlerTemplate.py
+++ b/phangsPipeline/handlerTemplate.py
@@ -431,10 +431,10 @@ class HandlerTemplate:
         considered.
         """
 
-        if len(self.get_cont_products()) is 0:
+        if len(self.get_cont_products()) == 0:
             return(self.get_line_products())
 
-        if len(self.get_line_products()) is 0:
+        if len(self.get_line_products()) == 0:
             return(self.get_cont_products())
         
         return(self.get_line_products() + self.get_cont_products())

--- a/phangsPipeline/scBackups.py
+++ b/phangsPipeline/scBackups.py
@@ -340,7 +340,7 @@ def old_write_moment1_hybrid(cube,
                                     inherit_mask=False)
         
     elif type(broad_mask) is np.ndarray:
-        broad_cube = cube.with_mask(broad_mask.astype(np.bool),
+        broad_cube = cube.with_mask(broad_mask.astype(bool),
                                     inherit_mask=False)
 
     (mom0broad,

--- a/phangsPipeline/scDerivativeRoutines.py
+++ b/phangsPipeline/scDerivativeRoutines.py
@@ -1135,7 +1135,7 @@ def write_vquad(cubein,
     window : astropy.Quantity
         Spectral window over which the data should be smoothed
 
-    maxshift : np.float
+    maxshift : float
         Maximum number of channels that the algorithm can shift the
         peak estimator (default = 0.5).  Set to None to suppress clipping.
 

--- a/phangsPipeline/scMaskingRoutines.py
+++ b/phangsPipeline/scMaskingRoutines.py
@@ -58,7 +58,7 @@ def nchan_thresh_mask(cube, thresh=5., nchan=2):
                             where=(~np.isnan(cube)),
                             out=np.full(cube.shape, False, dtype=bool))
 
-    kernel = np.ones(nchan, dtype=np.bool)
+    kernel = np.ones(nchan, dtype=bool)
     kernel = kernel[:,np.newaxis,np.newaxis]
 
     mask = morph.binary_opening(mask, kernel)
@@ -176,7 +176,7 @@ def grow_mask(mask, iters_xy=0, iters_v=0, constraint=None):
 
     if iters_v > 0:
 
-        struct = np.ones(iters_v, dtype=np.bool)
+        struct = np.ones(iters_v, dtype=bool)
         struct = struct[:, np.newaxis, np.newaxis]
 
         if iters_xy > 0:
@@ -200,7 +200,7 @@ def grow_mask(mask, iters_xy=0, iters_v=0, constraint=None):
         good_regions = np.unique(regions[mask])
 
         # create a new mask that includes only these good new regions
-        mask = np.zeros_like(mask, dtype=np.bool)
+        mask = np.zeros_like(mask, dtype=bool)
         for hit in good_regions:
             mask[regions == hit] = True
 
@@ -492,7 +492,7 @@ def make_vfield_mask(cube, vfield, window,
     # Write to disk
     # -------------------------------------------------
     
-    mask = SpectralCube(mask.astype(np.int), wcs=cube.wcs,
+    mask = SpectralCube(mask.astype(int), wcs=cube.wcs,
                         header=cube.header,
                         meta={'BUNIT': ' ', 'BTYPE': 'Mask'})
     
@@ -586,13 +586,13 @@ def join_masks(orig_mask_in, new_mask_in,
         x, y, _ = new_mask.wcs.wcs_world2pix(*(orig_mask.world[0,:,:][::-1]), 0)
         _, _, z = new_mask.wcs.wcs_world2pix(*(orig_mask.world[:,0,0][::-1]), 0)
 
-        x = np.rint(x).astype(np.int)
-        y = np.rint(y).astype(np.int)
-        z = np.rint(z).astype(np.int)
-        new_mask_data = np.array(new_mask.filled_data[:].value > thresh, dtype=np.bool)
+        x = np.rint(x).astype(int)
+        y = np.rint(y).astype(int)
+        z = np.rint(z).astype(int)
+        new_mask_data = np.array(new_mask.filled_data[:].value > thresh, dtype=bool)
 
         # Create new mask
-        new_mask_vals = np.zeros(orig_mask.shape, dtype=np.bool)
+        new_mask_vals = np.zeros(orig_mask.shape, dtype=bool)
         # Find all values that are in bounds
         inbounds = reduce((lambda A, B: np.logical_and(A, B)),
                           [(z[:,np.newaxis,np.newaxis] >= 0),
@@ -603,9 +603,9 @@ def join_masks(orig_mask_in, new_mask_in,
                            (x[np.newaxis,:,:] < new_mask.shape[2])])
 #        inbounds = np.logical_and.reduce(
         # Look 'em up in the new_mask
-        new_mask_vals[inbounds] = new_mask_data[(z[:,np.newaxis,np.newaxis]*np.ones(inbounds.shape, dtype=np.int))[inbounds],
-                                                (y[np.newaxis,:,:]*np.ones(inbounds.shape, dtype=np.int))[inbounds],
-                                                (x[np.newaxis,:,:]*np.ones(inbounds.shape, dtype=np.int))[inbounds]]
+        new_mask_vals[inbounds] = new_mask_data[(z[:,np.newaxis,np.newaxis]*np.ones(inbounds.shape, dtype=int))[inbounds],
+                                                (y[np.newaxis,:,:]*np.ones(inbounds.shape, dtype=int))[inbounds],
+                                                (x[np.newaxis,:,:]*np.ones(inbounds.shape, dtype=int))[inbounds]]
 
     else:
 
@@ -613,7 +613,7 @@ def join_masks(orig_mask_in, new_mask_in,
         new_mask = new_mask.reproject(orig_mask.header, order=order)
         new_mask = new_mask.spectral_interpolate(orig_mask.spectral_axis)
         new_mask_vals = np.array(new_mask.filled_data[:].value > thresh,
-                                 dtype=np.bool)
+                                 dtype=bool)
 
     # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
     # Combine
@@ -621,11 +621,11 @@ def join_masks(orig_mask_in, new_mask_in,
 
     if operation.strip().lower() == 'or':
         mask = np.logical_or(np.array(orig_mask.filled_data[:].value > thresh,
-                                      dtype=np.bool),
+                                      dtype=bool),
                              new_mask_vals)
     elif operation.strip().lower() == 'and':
         mask = np.logical_and(np.array(orig_mask.filled_data[:].value > thresh,
-                                       dtype=np.bool),
+                                       dtype=bool),
                               new_mask_vals)
     elif operation.strip().lower() == 'sum':
         mask = (orig_mask.filled_data[:].value) + new_mask_vals
@@ -637,7 +637,7 @@ def join_masks(orig_mask_in, new_mask_in,
     # Write to disk, return output, etc.
     # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
 
-    mask = SpectralCube(mask.astype(np.int), wcs=orig_mask.wcs,
+    mask = SpectralCube(mask.astype(int), wcs=orig_mask.wcs,
                         header=orig_mask.header,
                         meta={'BUNIT': ' ', 'BTYPE': 'Mask'})
 

--- a/phangsPipeline/scMoments.py
+++ b/phangsPipeline/scMoments.py
@@ -125,7 +125,7 @@ def moment_generator(
         # here or (better) build a masking routine to apply masks with
         # arbitrary astrometry.
 
-        mask = np.array(mask.filled_data[:].value, dtype=np.bool)
+        mask = np.array(mask.filled_data[:].value, dtype=bool)
         cube = cube.with_mask(mask, inherit_mask=False)
 
     # Read in the noise (if present)

--- a/phangsPipeline/scNoiseRoutines.py
+++ b/phangsPipeline/scNoiseRoutines.py
@@ -37,7 +37,7 @@ def mad_zero_centered(data, mask=None):
     Keywords:
     ---------
 
-    mask : np.bool
+    mask : bool
 
         Boolean array with True indicating where data can be used in
         the noise estimate. (i.e., True is noise). If none is supplied
@@ -112,18 +112,18 @@ def noise_cube(data, mask=None,
     Keywords:
     ---------
 
-    mask : np.bool
+    mask : bool
 
         Boolean array with False indicating where data can be
         used in the noise estimate. (i.e., True is signal)
 
-    do_map : np.bool
+    do_map : bool
 
         Estimate spatial variations in the noise. Default is True. If
         set to False, all locations in a plane have the same noise
         estimate.
 
-    do_spec : np.bool
+    do_spec : bool
 
         Estimate spectral variations in the noise. Default is True. If
         set to False, all channels in a spectrum have the same noise
@@ -175,7 +175,7 @@ def noise_cube(data, mask=None,
     # used for convenience.
 
     if box is not None:
-        step = np.floor(box/2.5).astype(np.int)
+        step = np.floor(box/2.5).astype(int)
         halfbox = int(box // 2)
 
     # Include all pixels adjacent to the spatial
@@ -195,7 +195,7 @@ def noise_cube(data, mask=None,
     # calculate a spectral step size.
 
     if spec_box is not None:
-        spec_step = np.floor(spec_box / 2).astype(np.int)
+        spec_step = np.floor(spec_box / 2).astype(int)
         boxv = int(spec_box // 2)
     else:
         boxv = 0
@@ -410,7 +410,7 @@ def recipe_phangs_noise(
     Keywords:
     ---------
 
-    mask : np.bool
+    mask : bool
 
         Boolean array with False indicating where data can be used in
         the noise estimate. (i.e., True is signal).

--- a/phangsPipeline/scStackingRoutines.py
+++ b/phangsPipeline/scStackingRoutines.py
@@ -48,7 +48,7 @@ def ShuffleCube(DataCube, centroid_map, chunk=1000):
     centroids = centroid_map[y, x]
     sortindex = np.argsort(spaxis)
     channel_shift = -1 * np.interp(centroids, spaxis[sortindex],
-                                   np.array(relative_channel[sortindex], dtype=np.float))
+                                   np.array(relative_channel[sortindex], dtype=float))
     NewCube = np.empty(DataCube.shape)
     NewCube.fill(np.nan)
     nchunk = (len(x) // chunk)
@@ -96,7 +96,7 @@ def BinByMask(DataCube, mask, centroid_map, weight_map=None):
     centroids = centroid_map[y, x].to(DataCube.spectral_axis.unit).value
     sortindex = np.argsort(spaxis)
     channel_shift = -1 * np.interp(centroids, spaxis[sortindex],
-                                   np.array(relative_channel[sortindex], dtype=np.float))
+                                   np.array(relative_channel[sortindex], dtype=float))
     spectra = DataCube.filled_data[:, y, x].value
     shifted_spectra = channelShiftVec(spectra, channel_shift)
     if weight_map is not None:

--- a/phangsPipeline/scTemp.py
+++ b/phangsPipeline/scTemp.py
@@ -66,7 +66,7 @@ def batch_moment_generator(
     if mask is not None:
         if type(mask) is str:
             mask_hdu = fits.open(mask)
-            mask = np.array(mask_hdu[0].data, dtype=np.bool)
+            mask = np.array(mask_hdu[0].data, dtype=bool)
         cube = cube.with_mask(mask, inherit_mask=False)
     elif generate_mask:
         cube, rms = phangs_mask(cube, mask_kwargs=mask_kwargs,


### PR DESCRIPTION
Some tidy-up to get the pipeline working in the latest pip-installed CASA environment. Retains backwards compatibility for earlier versions. Currently a draft until I've managed to chunk something through successfully, but I have got through imaging at least

* Add ReleaseHandler to __init__.py
* Various import fixes for newer python/CASA versions
* uvcontsub -> uvcontsub_old for new CASA versions
* Fix 'if' statements for == instead of 'is'
* Remove deprecated np.float calls
* Replace 'clobber' with 'overwrite' for hdu.writeto() calls if using astropy
