### PR TITLE
Handle empty masks for Tpeak

### DIFF
--- a/phangsPipeline/scDerivativeRoutines.py
+++ b/phangsPipeline/scDerivativeRoutines.py
@@ -916,11 +916,15 @@ def write_tmax(cubein,
 
     mask = cubein.get_mask_array()
     mask_spec = np.any(mask, axis=(1,2))
-    lo = np.min(np.where(mask_spec))
-    hi = np.max(np.where(mask_spec))
+
     mask = np.zeros_like(mask,dtype='bool')
-    mask[lo:hi,:,:] = True
+    if np.sum(mask_spec) != 0:
+        lo = np.min(np.where(mask_spec))
+        hi = np.max(np.where(mask_spec))
+        mask[lo:hi,:,:] = True
+
     mask *= np.isfinite(cubein.unmasked_data[:])
+
     new_cube = cubein.with_mask(mask, inherit_mask=False)
 
     # spectral smoothing if desired


### PR DESCRIPTION
`write_tmax` fails when the mask is empty in more recent versions of numpy (as `np.min/max` now raises an error when passed an empty array).