### PR TITLE
Temp imaging directories for chunked imaging handling

### DIFF
--- a/phangsPipeline/handlerImagingChunked.py
+++ b/phangsPipeline/handlerImagingChunked.py
@@ -100,8 +100,6 @@ if casa_enabled:
             self.image_root = utilsFilenames.get_cube_filename(target=target, product=product, config=config,
                                                                casa=True, casaext='')
 
-            self.full_image_root = os.path.join(self._orig_imaging_dir, self.image_root)
-
             if imaging_method not in ['tclean', 'sdintimaging']:
                 logger.error('imaging_method should be either tclean or sdintimaging')
                 raise Exception('imaging_method should be either tclean or sdintimaging')

--- a/phangsPipeline/handlerImagingChunked.py
+++ b/phangsPipeline/handlerImagingChunked.py
@@ -1548,7 +1548,6 @@ if casa_enabled:
 
             if do_singlescale_mask:
                 self.task_singlescale_mask(chunk_num=chunk_num,
-                                           imaging_dir=imaging_dir,
                                            imaging_method=imaging_method,
                                            high_snr=singlescale_mask_high_snr,
                                            low_snr=singlescale_mask_low_snr,

--- a/phangsPipeline/handlerImagingChunked.py
+++ b/phangsPipeline/handlerImagingChunked.py
@@ -8,6 +8,7 @@ This code needs to be run inside CASA.
 """
 
 import os, sys, re, shutil
+import datetime
 from copy import deepcopy, copy
 import glob
 import logging
@@ -65,6 +66,7 @@ if casa_enabled:
             force_square=False,
             oversamp=5,
             make_temp_dir=True,
+            temp_key=None,
             ):
 
             # inherit template class
@@ -128,7 +130,9 @@ if casa_enabled:
 
 
             if make_temp_dir:
-                self._this_imaging_dir = f"{self._orig_imaging_dir}/chunk_{chunk_num}"
+                if temp_key is None:
+                    temp_key = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S-%f")
+                self._this_imaging_dir = f"{self._orig_imaging_dir}/temp_{self.image_root}_{temp_key}"
                 os.makedirs(self._this_imaging_dir, exist_ok=True)
             else:
                 self._this_imaging_dir = self._orig_imaging_dir
@@ -268,7 +272,7 @@ if casa_enabled:
                 singlescale_mask_high_snr=None,
                 singlescale_mask_low_snr=None,
                 singlescale_mask_absolute=False,
-                skip_singlescale_if_mask_empty=True,                                
+                skip_singlescale_if_mask_empty=True,
                 do_singlescale_clean=False,
                 do_revert_to_singlescale=False,
                 do_export_to_fits=False,
@@ -1195,7 +1199,7 @@ if casa_enabled:
                 gather_chunks_into_cube=False,
                 remove_chunks=False,
                 threshold_value=1.0,
-                skip_singlescale_if_mask_empty=True,                
+                skip_singlescale_if_mask_empty=True,
                 backup=True,
         ):
             """
@@ -1247,7 +1251,7 @@ if casa_enabled:
                         skip_this_step = True
                         logger.info("")
                         logger.info("The clean mask is empty and SKIP_SINGLESCALE_IF_MASK_EMPTY is True. Skipping the singlescale clean step.")
-                        logger.info("")                        
+                        logger.info("")
 
                 if not skip_this_step:
                     imr.clean_loop(

--- a/phangsPipeline/handlerImagingChunked.py
+++ b/phangsPipeline/handlerImagingChunked.py
@@ -46,6 +46,39 @@ if casa_enabled:
     class ImagingChunkedHandler(handlerTemplate.HandlerTemplate):
         """
         Class to makes image cubes out of uv data for imaging a single spectral line.
+
+        Parameters
+        ----------
+        target : str
+            The target name.
+        config : str
+            The configuration name.
+        product : str
+            The product name.
+        key_handler : dict
+            The key handler dictionary.
+        dry_run : bool, optional
+            If True, do not actually make the images. Defaults to False.
+        chunksize : int, optional
+            The number of channels per image cube. Defaults to 10.
+        imaging_method : str, optional
+            The imaging method. Defaults to 'tclean'.
+        recipe : str, optional
+            The recipe. Defaults to 'phangsalma'.
+        set_cell_imsize_on_init : bool, optional
+            If True, set the cell size on initialization. Defaults to True.
+        force_square : bool, optional
+            If True, force the image size to be square. Defaults to False.
+        oversamp : int, optional
+            The oversampling factor of pixels per beam FWHM. Defaults to 5.
+        make_temp_dir : bool, optional
+            If True, make a temporary directory. Defaults to True.
+        temp_key : str, optional
+            The temporary key. Defaults to None.
+        temp_path : str, optional
+            The temporary path. Defaults to None. Set this to specify an independent path for the
+            temporary directory that is unassociated with the default imaging directory.
+
         """
 
         ############
@@ -67,6 +100,7 @@ if casa_enabled:
             oversamp=5,
             make_temp_dir=True,
             temp_key=None,
+            temp_path=None,
             ):
 
             # inherit template class
@@ -130,10 +164,15 @@ if casa_enabled:
 
 
             if make_temp_dir:
-                if temp_key is None:
-                    temp_key = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S-%f")
-                self._this_imaging_dir = f"{self._orig_imaging_dir}/temp_{self.image_root}_{temp_key}"
+                if temp_path is None:
+                    if temp_key is None:
+                        temp_key = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S-%f")
+                    self._this_imaging_dir = f"{self._orig_imaging_dir}/temp_{self.image_root}_{temp_key}"
+                else:
+                    self._this_imaging_dir = temp_path
+
                 os.makedirs(self._this_imaging_dir, exist_ok=True)
+
             else:
                 self._this_imaging_dir = self._orig_imaging_dir
 

--- a/phangsPipeline/handlerImagingChunked.py
+++ b/phangsPipeline/handlerImagingChunked.py
@@ -316,7 +316,6 @@ if casa_enabled:
 
             if self.recipe == 'phangsalma':
                 self.recipe_phangsalma_imaging(
-                    imaging_dir=self._this_imaging_dir,
                     chunk_num=chunk_num,
                     extra_ext_in=extra_ext_in,
                     suffix_in=suffix_in,
@@ -837,7 +836,7 @@ if casa_enabled:
 
             if not self._dry_run and casa_enabled:
 
-                self._kh.get_imaging_dir_for_target(self.target, changeto=True)
+                os.chdir(self._this_imaging_dir)
 
                 for ii, chunk_num in enumerate(chunks_iter):
 
@@ -1023,7 +1022,7 @@ if casa_enabled:
 
             for ii, chunk_num in enumerate(chunks_iter):
 
-                self._kh.get_imaging_dir_for_target(self.target, changeto=True)
+                os.chdir(self._this_imaging_dir)
 
                 # Make the chunk clean call:
                 this_clean_call = self.task_initialize_clean_call(chunk_num, stage='multiscale')
@@ -1220,7 +1219,7 @@ if casa_enabled:
 
             for ii, chunk_num in enumerate(chunks_iter):
 
-                self._kh.get_imaging_dir_for_target(self.target, changeto=True)
+                os.chdir(self._this_imaging_dir)
 
                 # Make the chunk clean call:
                 this_clean_call = self.task_initialize_clean_call(chunk_num, stage='singlescale')
@@ -1365,7 +1364,7 @@ if casa_enabled:
 
             for ii, this_chunk_num in enumerate(chunks_iter):
 
-                self._kh.get_imaging_dir_for_target(self.target, changeto=True)
+                os.chdir(self._this_imaging_dir)
 
                 chan_start, chan_end = self.chunk_params[this_chunk_num]['channel_range']
                 chan_label = "{0}_{1}".format(chan_start, chan_end)
@@ -1385,7 +1384,6 @@ if casa_enabled:
         def recipe_phangsalma_imaging(
                 self,
                 chunk_num=None,
-                imaging_dir=None,
                 extra_ext_in=None,
                 suffix_in=None,
                 extra_ext_out=None,
@@ -1468,7 +1466,6 @@ if casa_enabled:
 
             if do_dirty_image:
                 self.task_make_dirty_image(chunk_num=chunk_num,
-                                           imaging_dir=imaging_dir,
                                            imaging_method=imaging_method,
                                            gather_chunks_into_cube=gather_chunks_into_cube)
 
@@ -1476,7 +1473,6 @@ if casa_enabled:
 
             if do_revert_to_dirty:
                 self.task_revert_to_imaging(chunk_num=chunk_num,
-                                            imaging_dir=imaging_dir,
                                             imaging_method=imaging_method,
                                             tag='dirty')
 
@@ -1495,7 +1491,6 @@ if casa_enabled:
 
             if do_multiscale_clean:
                 self.task_multiscale_clean(chunk_num=chunk_num,
-                                           imaging_dir=imaging_dir,
                                            imaging_method=imaging_method,
                                            convergence_fracflux=convergence_fracflux,
                                            gather_chunks_into_cube=gather_chunks_into_cube,
@@ -1505,7 +1500,6 @@ if casa_enabled:
 
             if do_revert_to_multiscale:
                 self.task_revert_to_imaging(chunk_num=chunk_num,
-                                            imaging_dir=imaging_dir,
                                             imaging_method=imaging_method,
                                             tag='multiscale')
 
@@ -1523,7 +1517,6 @@ if casa_enabled:
 
             if do_singlescale_clean:
                 self.task_singlescale_clean(chunk_num=chunk_num,
-                                            imaging_dir=imaging_dir,
                                             imaging_method=imaging_method,
                                             convergence_fracflux=convergence_fracflux,
                                             threshold_value=singlescale_threshold_value,
@@ -1534,7 +1527,6 @@ if casa_enabled:
 
             if do_revert_to_singlescale:
                 self.task_revert_to_imaging(chunk_num=chunk_num,
-                                            imaging_dir=imaging_dir,
                                             imaging_method=imaging_method,
                                             tag='singlescale')
 
@@ -1546,11 +1538,10 @@ if casa_enabled:
             # Ensure products are re-combined into cubes:
             if do_recombine_cubes:
                 if chunk_num is None:
-                    self.task_complete_gather_into_cubes(root_name='all', imaging_dir=imaging_dir)
+                    self.task_complete_gather_into_cubes(root_name='all')
                                 # Export the products of the current clean to FITS files.
                     if do_export_to_fits:
-                        self.task_export_to_fits(imaging_method=imaging_method,
-                                                 imaging_dir=imaging_dir,)
+                        self.task_export_to_fits(imaging_method=imaging_method)
 
                 else:
                     import warnings

--- a/phangsPipeline/handlerImagingChunked.py
+++ b/phangsPipeline/handlerImagingChunked.py
@@ -128,10 +128,10 @@ if casa_enabled:
 
 
             if make_temp_dir:
-                self._this_imaging_dir = f"{this_imaging_dir}/chunk_{chunk_num}"
+                self._this_imaging_dir = f"{self._orig_imaging_dir}/chunk_{chunk_num}"
                 os.makedirs(self._this_imaging_dir, exist_ok=True)
             else:
-                self._this_imaging_dir = this_imaging_dir
+                self._this_imaging_dir = self._orig_imaging_dir
 
             # Set a flag to check on whether we need to move clean-up the final products
             self._uses_tempdir = make_temp_dir


### PR DESCRIPTION
Implement temp dirs when imaging in chunks to avoid overlapping casa temp products. 

I'm hitting issues with the filesystem I'm running this on where the casa temporary gridding and weight products are interacting between the separate jobs running each chunk (since the processing is all in the same directory).