### PR TITLE
added masking of rolled spectra to shuffling.

### DIFF
--- a/phangsPipeline/scMaskingRoutines.py
+++ b/phangsPipeline/scMaskingRoutines.py
@@ -433,7 +433,7 @@ def make_vfield_mask(cube_in, vfield_in, window_in,
     else:
         cube = cube_in
 
-    # Get spectral information from the cube        
+    # Get spectral information from the cube
     spaxis = cube.spectral_axis
     spunit = spaxis.unit
     spvalue = spaxis.value

--- a/phangsPipeline/scStackingRoutines.py
+++ b/phangsPipeline/scStackingRoutines.py
@@ -204,6 +204,18 @@ def ShuffleCube(
         # ... apply the mask
         shifted_spectra[shifted_mask>0.5] = np.nan
 
+        # ... also mask the region where the spectrum "wrapped" due to the FFT
+
+        max_channel = len(spaxis)*1.0
+        channels = np.arange(max_channel)
+        channel_grid = np.tile(channels.reshape((len(spaxis),1)),(1,shifted_spectra.shape[1]))
+        shift_grid = np.tile(this_shift,(shifted_spectra.shape[0],1))
+
+        wrap_mask = (shift_grid >= 0.)*(channel_grid <= shift_grid) + \
+            (shift_grid < 0)*(channel_grid >= (max_channel + shift_grid - 1))
+        
+        shifted_spectra[wrap_mask > 0.5] = np.nan        
+        
         # ... save in the cube
         new_cube[:, this_y, this_x] = shifted_spectra
 


### PR DESCRIPTION
Added masking of the "rolled around" channels in Shuffling.

I tested this on M31 and M33 ALMA and IRAM and it looks okay but I think there are some spaces to optimize. In particular I wasn't sure how zip worked on the last step - if it can be relied on to produce a constant size could move the channel grid creation out of the loop and save a bit. I'm sure there's some other cleverness possible too. But it seems to work (but also please check!).

If no one has time I'll just merge and people can shout as they hit bugs. Right now the behavior is bad in master so it's not a huge loss.