### PR TITLE
Stop crash when one part of mosaic doesn't exist

### DIFF
--- a/phangsPipeline/casaMosaicRoutines.py
+++ b/phangsPipeline/casaMosaicRoutines.py
@@ -85,6 +85,10 @@ def common_res_for_mosaic(
         logger.error("Missing required infile_list.")
         return(None)
 
+    if len(infile_list) == 0:
+        logger.error("No files to process.")
+        return None
+
     for this_file in infile_list:
         if os.path.isdir(this_file) == False:
             logger.error("File not found "+this_file)
@@ -558,6 +562,10 @@ def common_grid_for_mosaic(
         logger.error("Infile list missing.")
         return(None)
 
+    if len(infile_list) == 0:
+        logger.error("No files to process.")
+        return None
+
     for this_infile in infile_list:
         if os.path.isdir(this_infile) == False:
             logger.error("File "+this_infile+" not found. Continuing.")
@@ -853,6 +861,10 @@ def mosaic_aligned_data(
     if infile_list is None:
         logger.error("Input file list required.")
         return(None)
+
+    if len(infile_list) == 0:
+        logger.error("No files to process.")
+        return None
 
     if outfile is None:
         logger.error("Output file is required.")

--- a/phangsPipeline/handlerPostprocess.py
+++ b/phangsPipeline/handlerPostprocess.py
@@ -55,10 +55,12 @@ class PostProcessHandler(handlerTemplate.HandlerTemplate):
         self,
         key_handler = None,
         dry_run = False,
+        raise_exception_mosaic_part_missing = False,
         ):
 
         # inherit template class
         handlerTemplate.HandlerTemplate.__init__(self, key_handler = key_handler, dry_run = dry_run)
+        self.raise_exception_mosaic_part_missing = raise_exception_mosaic_part_missing
 
 #region File name routines
 
@@ -1286,8 +1288,19 @@ class PostProcessHandler(handlerTemplate.HandlerTemplate):
                 extra_ext=extra_ext_out,
                 )
 
-            infile_list.append(indir+this_part_dict_in[in_tag])
-            outfile_list.append(outdir+this_part_dict_out[out_tag])
+            infile = indir+this_part_dict_in[in_tag]
+            infile_exists = os.path.isdir(infile)
+
+            outfile = outdir+this_part_dict_out[out_tag]
+
+            if infile_exists:
+                infile_list.append(infile)
+                outfile_list.append(outfile)
+            else:
+                if self.raise_exception_mosaic_part_missing:
+                    raise FileNotFoundError("Missing file "+infile)
+                else:
+                    logger.warning("Missing file "+infile)
 
         logger.info("")
         logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%")
@@ -1381,8 +1394,20 @@ class PostProcessHandler(handlerTemplate.HandlerTemplate):
             for this_tag_in in in_tags:
 
                 this_tag_out = out_tag_dict[this_tag_in]
-                infile_list.append(indir+this_part_dict_in[this_tag_in])
-                outfile_list.append(outdir+this_part_dict_out[this_tag_out])
+
+                infile = indir+this_part_dict_in[this_tag_in]
+                infile_exists = os.path.isdir(infile)
+
+                outfile = outdir+this_part_dict_out[this_tag_out]
+
+                if infile_exists:
+                    infile_list.append(infile)
+                    outfile_list.append(outfile)
+                else:
+                    if self.raise_exception_mosaic_part_missing:
+                        raise FileNotFoundError("Missing file " + infile)
+                    else:
+                        logger.warning("Missing file " + infile)
 
         logger.info("")
         logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%")
@@ -1465,8 +1490,27 @@ class PostProcessHandler(handlerTemplate.HandlerTemplate):
                 extra_ext=extra_ext_in,
                 )
 
-            infile_list.append(indir+this_part_dict_in[image_tag])
-            weightfile_list.append(indir+this_part_dict_in[weight_tag])
+            # Only include these files if both imaging and weights exist
+            infile = indir+this_part_dict_in[image_tag]
+            weightfile = indir+this_part_dict_in[weight_tag]
+
+            infile_exists = os.path.isdir(infile)
+            weightfile_exists = os.path.isdir(weightfile)
+
+            if infile_exists and weightfile_exists:
+                infile_list.append(infile)
+                weightfile_list.append(weightfile)
+            else:
+                if not infile_exists:
+                    if self.raise_exception_mosaic_part_missing:
+                        raise FileNotFoundError("Missing file " + infile)
+                    else:
+                        logger.warning("Missing file " + infile)
+                if not weightfile_exists:
+                    if self.raise_exception_mosaic_part_missing:
+                        raise FileNotFoundError("Missing file " + weightfile)
+                    else:
+                        logger.warning("Missing file "+weightfile)
 
         logger.info("")
         logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%")


### PR DESCRIPTION
Currently, the mosaicking in postprocessing will skip stitching if any "expected" files don't exist. But, it's not very smart about checking these things (it expects every part to have every configuration), so you can have an instance where you have mosaic parts that might not have certain configurations:

- ngc7793_1 only has 12m
- ngc7793_2 has 7m
- ngc7793_3 has 7m
- ngc7793_4 has 12m+7m+tp

and then it'll not do a 12m mosaic of 1 and 4, or a 7m mosaic of 2/3/4. This adds some logic to check parts exist first, thus avoiding the skip. Also adds warnings if files are missing, in case this isn't intended behaviour for the end user.

Importantly, this works if the heterogeneous observations don't have overlap between each other. It then just saves duplicating targets to avoid this behaviour
