### PR TITLE
Properly use nchan in the imaging

### DIFF
--- a/phangsPipeline/casaImagingRoutines.py
+++ b/phangsPipeline/casaImagingRoutines.py
@@ -624,7 +624,15 @@ def clean_loop(
     # of iterations that we give to an individual clean call.
 
     vm = au.ValueMapping(working_call.get_param('vis'))
-    nchan = vm.spwInfo[0]['numChannels']
+
+    # If we have a number of channels defined, then use that
+    nchan = working_call.get_param('nchan')
+
+    # Otherwise, pull the total number of channels from the spwInfo
+    if nchan is None:
+        nchan = -1
+    if nchan <= 0:
+        nchan = vm.spwInfo[0]['numChannels']
 
     # Create a text record of progress through successive clean calls.
 

--- a/phangsPipeline/handlerImagingChunked.py
+++ b/phangsPipeline/handlerImagingChunked.py
@@ -101,6 +101,7 @@ if casa_enabled:
             make_temp_dir=True,
             temp_key=None,
             temp_path=None,
+            copy_ms_to_temp=False,
             ):
 
             # inherit template class
@@ -162,7 +163,6 @@ if casa_enabled:
             # Make needed directories
             self._kh.make_missing_directories(imaging=True)
 
-
             if make_temp_dir:
                 if temp_path is None:
                     if temp_key is None:
@@ -172,6 +172,13 @@ if casa_enabled:
                     self._this_imaging_dir = temp_path
 
                 os.makedirs(self._this_imaging_dir, exist_ok=True)
+
+                if copy_ms_to_temp:
+                    # Copy the full MS file over, to speed up disk I/O
+                    os.system(f"cp -r {os.path.join(self._orig_imaging_dir, self.vis_file)} {self._this_imaging_dir}")
+
+                    # The full visibility file is now in the imaging directory
+                    self.full_vis_file = os.path.join(self._this_imaging_dir, self.vis_file)
 
             else:
                 self._this_imaging_dir = self._orig_imaging_dir


### PR DESCRIPTION
- If nchan is defined, use that. Else fallback to the entire SPW. Required for chunked imaging to calculate correctly
- For chunked imaging, if using a temporary directory optionally copy the MS over for speed (False by default)
