### PR TITLE
Add TestImagingHandler 

### DIFF
--- a/phangsPipeline/__init__.py
+++ b/phangsPipeline/__init__.py
@@ -20,12 +20,14 @@ from .handlerRelease import ReleaseHandler
 
 if casa_enabled:
     from .handlerImaging import ImagingHandler
+    from .handlerTestImaging import TestImagingHandler
 
 __all__ = ["setup_logger", "KeyHandler", "SingleDishHandler", "VisHandler", "PostProcessHandler", "DerivedHandler",
            "ReleaseHandler"]
 
 if casa_enabled:
     __all__.append("ImagingHandler")
+    __all__.append("TestImagingHandler")
 
 try:
     from .handlerAlmaDownload import AlmaDownloadHandler

--- a/phangsPipeline/handlerTestImaging.py
+++ b/phangsPipeline/handlerTestImaging.py
@@ -1,0 +1,1798 @@
+"""handlerTestImaging
+
+This module provides a test imaging handler for exploring different imaging
+parameters (weights, tapers) without running full deconvolution. It creates
+dirty images and PSFs for a single channel and summarizes the resulting
+beam properties and image statistics.
+
+This code needs to be run inside CASA.
+
+Example:
+    $ casa
+    from phangsPipeline import handlerKeys as kh
+    from phangsPipeline import handlerTestImaging as tih
+    this_kh = kh.KeyHandler(master_key = 'config_keys/master_key.txt')
+    this_tih = tih.TestImagingHandler(key_handler = this_kh)
+    this_tih.set_targets(only = ['ngc3627'])
+
+    # Define test parameters
+    this_tih.set_test_params(
+        weightings=['briggs', 'briggs', 'natural'],
+        robustnums=[0.5, 2.0, None],
+        tapers_arcsec=[0.0, 1.0, 0.0]
+    )
+
+    # Run the test imaging loop
+    results = this_tih.loop_test_imaging()
+
+    # Print summary
+    this_tih.print_summary()
+
+    # Generate all diagnostic plots and export CSV in one call
+    this_tih.make_report(output_prefix='ngc3627_test')
+
+    # Or call individual plot methods:
+    this_tih.plot_psf_radial_profiles(output_file='psf_profiles.png')
+    this_tih.plot_psf_gallery(output_file='psf_gallery.png',
+                              zoom_radius_arcsec=5.0)
+    this_tih.plot_image_gallery(output_file='image_gallery.png')
+"""
+
+import os
+import logging
+import numpy as np
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+# Check casa environment by importing CASA-only packages
+from .casa_check import is_casa_installed
+casa_enabled = is_casa_installed()
+
+if casa_enabled:
+    logger.debug('casa_enabled = True')
+    from . import casaImagingRoutines as imr
+else:
+    logger.debug('casa_enabled = False')
+
+if casa_enabled:
+
+    # Analysis utilities
+    import analysisUtils as au
+
+    from .clean_call import CleanCall
+
+    from . import utilsLines as lines
+    from . import handlerTemplate
+    from . import utilsFilenames
+    from . import casaStuff
+    from . import utilsTestImagingPlots as tip
+
+
+    class TestImagingHandler(handlerTemplate.HandlerTemplate):
+        """
+        Class to test different imaging parameters by creating dirty images
+        and PSFs for a single channel. Useful for exploring the effects of
+        different weighting schemes and uv-tapers on resolution and sensitivity.
+        """
+
+        ############
+        # __init__ #
+        ############
+
+        def __init__(
+            self,
+            key_handler=None,
+            dry_run=False,
+        ):
+            # Inherit template class
+            handlerTemplate.HandlerTemplate.__init__(self, key_handler=key_handler, dry_run=dry_run)
+
+            # Initialize test parameter lists
+            self._test_params = []
+
+            # Initialize results storage
+            self._test_results = []
+
+        ###################
+        # set_test_params #
+        ###################
+
+        def set_test_params(
+            self,
+            weightings=None,
+            robustnums=None,
+            tapers_arcsec=None,
+            test_names=None,
+        ):
+            """
+            Set the imaging parameter combinations to test.
+
+            Parameters
+            ----------
+            weightings : list
+                List of weighting schemes ('briggs', 'natural', 'uniform').
+            robustnums : list
+                List of robust parameters (only used for briggs weighting).
+                Use None for non-briggs weightings.
+            tapers_arcsec : list
+                List of outer UV taper values in arcseconds.
+                Use 0.0 for no taper.
+            test_names : list, optional
+                Custom names for each test combination. If not provided,
+                names are auto-generated from parameters.
+
+            All lists must have the same length.
+            """
+            if weightings is None:
+                weightings = ['briggs']
+            if robustnums is None:
+                robustnums = [0.5]
+            if tapers_arcsec is None:
+                # Default when no taper is given is to not taper.
+                tapers_arcsec = [0.0] * len(weightings)
+
+            # Ensure all lists have the same length
+            n_tests = len(weightings)
+            if len(robustnums) != n_tests or len(tapers_arcsec) != n_tests:
+                logger.error("weightings, robustnums, and tapers_arcsec must have same length")
+                raise ValueError("Parameter lists must have same length")
+
+            self._test_params = []
+            for i in range(n_tests):
+                if test_names is not None and len(test_names) > i:
+                    name = test_names[i]
+                else:
+                    # Auto-generate name
+                    name = weightings[i]
+                    if weightings[i] == 'briggs' and robustnums[i] is not None:
+                        name += '_r' + str(robustnums[i])
+                    if tapers_arcsec[i] > 0:
+                        name += '_t' + str(tapers_arcsec[i])
+
+                self._test_params.append({
+                    'name': name,
+                    'weighting': weightings[i],
+                    'robust': robustnums[i],
+                    'taper_arcsec': tapers_arcsec[i],
+                })
+
+            logger.info(f"Set {len(self._test_params)} test parameter combinations")
+            return self._test_params
+
+        def add_test_param(
+            self,
+            weighting='briggs',
+            robust=0.5,
+            taper_arcsec=0.0,
+            name=None,
+        ):
+            """
+            Add a single test parameter combination.
+
+            Parameters
+            ----------
+            weighting : str
+                Weighting scheme ('briggs', 'natural', 'uniform').
+            robust : float or None
+                Robust parameter for briggs weighting.
+            taper_arcsec : float
+                Outer UV taper in arcseconds (0.0 for no taper).
+            name : str, optional
+                Custom name for this test.
+            """
+            if name is None:
+                name = weighting
+                if weighting == 'briggs' and robust is not None:
+                    name += '_r' + str(robust)
+                if taper_arcsec > 0:
+                    name += '_t' + str(taper_arcsec)
+
+            self._test_params.append({
+                'name': name,
+                'weighting': weighting,
+                'robust': robust,
+                'taper_arcsec': taper_arcsec,
+            })
+
+            logger.info(f"Added test param: {name}")
+            return self._test_params
+
+        def get_test_params(self):
+            """Return the list of test parameter combinations."""
+            return self._test_params
+
+        def clear_test_params(self):
+            """Clear all test parameter combinations."""
+            self._test_params = []
+            return self._test_params
+
+        ###############
+        # _fname_dict #
+        ###############
+
+        def _fname_dict(
+            self,
+            product,
+            imagename,
+        ):
+            """
+            Handles file names used in the test imaging processes.
+            For test imaging we always use tclean with cube specmode
+            for a single channel.
+            """
+            fname_dict = {}
+            fname_dict['root'] = imagename
+            fname_dict['suffix'] = ''
+            fname_dict['image'] = imagename + '.image'
+            fname_dict['model'] = imagename + '.model'
+            fname_dict['residual'] = imagename + '.residual'
+            fname_dict['mask'] = imagename + '.mask'
+            fname_dict['pb'] = imagename + '.pb'
+            fname_dict['psf'] = imagename + '.psf'
+            fname_dict['weight'] = imagename + '.weight'
+            fname_dict['sumwt'] = imagename + '.sumwt'
+            return fname_dict
+
+        ########################
+        # _get_beam_properties #
+        ########################
+
+        def _get_beam_properties(
+            self,
+            psf_file,
+        ):
+            """
+            Extract beam properties from a PSF image.
+
+            Parameters
+            ----------
+            psf_file : str
+                Path to the PSF image.
+
+            Returns
+            -------
+            dict
+                Dictionary with beam major/minor axes (arcsec) and position angle (deg).
+            """
+            if not os.path.isdir(psf_file):
+                logger.warning(f"PSF file not found: {psf_file}")
+                return None
+
+            myia = au.createCasaTool(casaStuff.iatool)
+            myia.open(psf_file)
+
+            beam_info = {}
+            try:
+                restoring_beam = myia.restoringbeam()
+                if 'major' in restoring_beam:
+                    beam_info['bmaj_arcsec'] = restoring_beam['major']['value']
+                    if restoring_beam['major']['unit'] == 'deg':
+                        beam_info['bmaj_arcsec'] *= 3600.0
+                    beam_info['bmin_arcsec'] = restoring_beam['minor']['value']
+                    if restoring_beam['minor']['unit'] == 'deg':
+                        beam_info['bmin_arcsec'] *= 3600.0
+                    beam_info['bpa_deg'] = restoring_beam['positionangle']['value']
+                else:
+                    # No beam info in restoring beam
+                    beam_info['bmaj_arcsec'] = None
+                    beam_info['bmin_arcsec'] = None
+                    beam_info['bpa_deg'] = None
+            except Exception as e:
+                logger.warning(f"Could not extract beam from {psf_file}: {e}")
+                beam_info['bmaj_arcsec'] = None
+                beam_info['bmin_arcsec'] = None
+                beam_info['bpa_deg'] = None
+
+            myia.close()
+            return beam_info
+
+        ########################
+        # _get_image_statistics #
+        ########################
+
+        def _get_image_statistics(
+            self,
+            image_file,
+            pb_file=None,
+            pb_limit=0.7,
+        ):
+            """
+            Extract image statistics from a dirty image.
+
+            Parameters
+            ----------
+            image_file : str
+                Path to the dirty image.
+            pb_file : str, optional
+                Path to primary beam image for masking.
+            pb_limit : float
+                Primary beam level below which to exclude pixels.
+
+            Returns
+            -------
+            dict
+                Dictionary with image statistics (rms, max, min, etc.).
+            """
+            if not os.path.isdir(image_file):
+                logger.warning(f"Image file not found: {image_file}")
+                return None
+
+            stats = {}
+
+            # Get image statistics using imstat
+            if pb_file is not None and os.path.isdir(pb_file):
+                # Create a mask based on primary beam
+                stat_result = casaStuff.imstat(imagename=image_file,
+                                                mask=f'"{pb_file}" > {pb_limit}')
+            else:
+                stat_result = casaStuff.imstat(imagename=image_file)
+
+            if stat_result is not None:
+                stats['max'] = stat_result['max'][0] if 'max' in stat_result else None
+                stats['min'] = stat_result['min'][0] if 'min' in stat_result else None
+                stats['rms'] = stat_result['rms'][0] if 'rms' in stat_result else None
+                stats['mean'] = stat_result['mean'][0] if 'mean' in stat_result else None
+                stats['median'] = stat_result['median'][0] if 'median' in stat_result else None
+                stats['npts'] = stat_result['npts'][0] if 'npts' in stat_result else None
+            else:
+                stats['max'] = None
+                stats['min'] = None
+                stats['rms'] = None
+                stats['mean'] = None
+                stats['median'] = None
+                stats['npts'] = None
+
+            return stats
+
+        ###########################
+        # task_initialize_test_call #
+        ###########################
+
+        def task_initialize_test_call(
+            self,
+            target=None,
+            config=None,
+            product=None,
+            test_param=None,
+            extra_ext_in=None,
+            suffix_in=None,
+            channel=None,
+        ):
+            """
+            Initialize a clean call object for test imaging.
+
+            Parameters
+            ----------
+            target : str
+                Target name.
+            config : str
+                Configuration name.
+            product : str
+                Product name.
+            test_param : dict
+                Test parameter dictionary with weighting, robust, taper_arcsec.
+            extra_ext_in : str, optional
+                Extra extension for input files.
+            suffix_in : str, optional
+                Suffix for input files.
+            channel : int, optional
+                Channel to image. Defaults to 0 (first channel).
+            """
+            if target is None or config is None or product is None:
+                logger.error('Please input target, config and product!')
+                raise Exception('Please input target, config and product!')
+
+            if test_param is None:
+                logger.error('Please input test_param!')
+                raise Exception('Please input test_param!')
+
+            # Look up the recipes for this case
+            recipe_list = self._kh.get_imaging_recipes(config=config, product=product)
+            if recipe_list is None:
+                logger.error(
+                    f'Could not get imaging recipe for config {config} product {product}')
+                raise Exception(
+                    f'Could not get imaging recipe for config {config} product {product}')
+
+            # Initialize the clean call
+            clean_call = CleanCall(recipe_list, use_chunks=False)
+
+            # Get the visibility name
+            vis_file = utilsFilenames.get_vis_filename(
+                target=target, product=product, config=config,
+                ext=extra_ext_in, suffix=suffix_in)
+
+            # Test existence
+            full_vis_file = self._kh.get_imaging_dir_for_target(target=target) + vis_file
+            if not os.path.isdir(full_vis_file):
+                logger.error(f'Visibility file not found: {full_vis_file}')
+                return None
+
+            clean_call.set_param('vis', vis_file, nowarning=True)
+
+            # Set the output image file name with test param name
+            image_root = utilsFilenames.get_cube_filename(
+                target=target, product=product, config=config,
+                ext='test_' + test_param['name'], casa=True, casaext='')
+
+            clean_call.set_param('imagename', image_root, nowarning=True)
+
+            # Get the phase center
+            rastring, decstring = self._kh.get_phasecenter_for_target(target=target)
+            phasecenter = 'J2000 ' + rastring + ' ' + decstring
+            clean_call.set_param('phasecenter', phasecenter)
+
+            # Force cube mode for single channel
+            clean_call.set_param('specmode', 'cube')
+            clean_call.set_param('deconvolver', 'hogbom')
+
+            # Set single channel
+            if channel is None:
+                channel = 0
+
+            clean_call.set_param('nchan', 1)
+            clean_call.set_param('start', channel)
+            clean_call.set_param('width', 1)
+
+            # Set rest frequency for line products
+            is_line_product = product in self._kh.get_line_products()
+            if is_line_product:
+                this_line_tag = self._kh.get_line_tag_for_line_product(product=product)
+                if this_line_tag in lines.line_list.keys():
+                    rest_freq_ghz = lines.line_list[this_line_tag]
+                    clean_call.set_restfreq_ghz(rest_freq_ghz)
+
+            # Apply test parameters: weighting
+            clean_call.set_param('weighting', test_param['weighting'], nowarning=True)
+
+            if test_param['weighting'] == 'briggs' and test_param['robust'] is not None:
+                clean_call.set_param('robust', test_param['robust'], nowarning=True)
+
+            # Apply UV taper
+            if test_param['taper_arcsec'] > 0:
+                clean_call.set_round_uvtaper_arcsec(test_param['taper_arcsec'])
+            else:
+                clean_call.set_param('uvtaper', [], nowarning=True)
+
+            return clean_call
+
+        ############################
+        # task_make_test_dirty_image #
+        ############################
+
+        def task_make_test_dirty_image(
+            self,
+            clean_call=None,
+        ):
+            """
+            Execute the clean call with zero iterations to create a dirty
+            image and PSF for testing purposes.
+            """
+            logger.info("")
+            logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%")
+            logger.info("Making test dirty image:")
+            logger.info(str(clean_call.get_param('imagename')))
+            logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%")
+            logger.info("")
+
+            if not self._dry_run and casa_enabled:
+                imr.make_dirty_image(clean_call, imaging_method='tclean')
+
+            return ()
+
+        ######################
+        # loop_test_imaging #
+        ######################
+
+        def loop_test_imaging(
+            self,
+            extra_ext_in=None,
+            suffix_in=None,
+            channel=None,
+            make_directories=True,
+            overwrite=False,
+        ):
+            """
+            Loop over targets, products, configs, and test parameters to
+            create test dirty images and PSFs, then extract beam properties
+            and image statistics.
+
+            Parameters
+            ----------
+            extra_ext_in : str, optional
+                Extra extension for input files.
+            suffix_in : str, optional
+                Suffix for input files.
+            channel : int, optional
+                Channel to image. Defaults to 0 (first channel).
+            make_directories : bool
+                Create missing directories.
+            overwrite : bool
+                Overwrite existing test images.
+
+            Returns
+            -------
+            list
+                List of result dictionaries for each test.
+            """
+            if len(self._test_params) == 0:
+                logger.error("No test parameters set. Use set_test_params() first.")
+                return []
+
+            if len(self.get_targets()) == 0:
+                logger.error("Need a target list.")
+                return []
+
+            if len(self.get_all_products()) == 0:
+                logger.error("Need a products list.")
+                return []
+
+            if make_directories:
+                self._kh.make_missing_directories(imaging=True)
+
+            # Clear previous results
+            self._test_results = []
+
+            # Save initial directory to restore when done
+            initial_dir = os.getcwd()
+
+            try:
+                # Loop over targets, products, and configs
+                for this_target, this_product, this_config in \
+                        self.looper(do_targets=True, do_products=True, do_configs=True, just_interf=True):
+
+                    # Change to the relevant directory
+                    this_imaging_dir = self._kh.get_imaging_dir_for_target(this_target, changeto=True)
+
+                    # Loop over test parameters
+                    for test_param in self._test_params:
+                        logger.info("")
+                        logger.info("=" * 60)
+                        logger.info(f"TEST IMAGING: {this_target} {this_config} {this_product}")
+                        logger.info(f"Test params: {test_param['name']}")
+                        logger.info("=" * 60)
+
+                        # Initialize result dictionary
+                        result = {
+                            'target': this_target,
+                            'config': this_config,
+                            'product': this_product,
+                            'test_name': test_param['name'],
+                            'weighting': test_param['weighting'],
+                            'robust': test_param['robust'],
+                            'taper_arcsec': test_param['taper_arcsec'],
+                        }
+
+                        # Initialize clean call
+                        clean_call = self.task_initialize_test_call(
+                            target=this_target,
+                            config=this_config,
+                            product=this_product,
+                            test_param=test_param,
+                            extra_ext_in=extra_ext_in,
+                            suffix_in=suffix_in,
+                            channel=channel,
+                        )
+
+                        if clean_call is None:
+                            logger.warning("Could not create clean call, skipping")
+                            result['status'] = 'failed'
+                            result['error'] = 'Could not create clean call'
+                            self._test_results.append(result)
+                            continue
+
+                        # Get file names
+                        fname_dict = self._fname_dict(
+                            product=this_product,
+                            imagename=clean_call.get_param('imagename')
+                        )
+
+                        # Check if we should skip
+                        if not overwrite and os.path.isdir(fname_dict['psf']):
+                            logger.info(f"Test image exists, skipping: {fname_dict['psf']}")
+                            result['status'] = 'skipped'
+                        else:
+                            # Pick cell and imsize
+                            if not self._dry_run:
+                                cell, imsize = imr.estimate_cell_and_imsize(
+                                    clean_call.get_param('vis'), oversamp=5, force_square=False)
+                                clean_call.set_param('cell', cell, nowarning=True)
+                                clean_call.set_param('imsize', imsize, nowarning=True)
+                            else:
+                                clean_call.set_param('cell', '0.1arcsec', nowarning=True)
+                                clean_call.set_param('imsize', [1000, 1000], nowarning=True)
+
+                            # Record pixel scale
+                            cell_str = clean_call.get_param('cell')
+                            if isinstance(cell_str, str):
+                                result['cell_arcsec'] = float(
+                                    cell_str.replace('arcsec', ''))
+                            else:
+                                result['cell_arcsec'] = float(cell_str)
+
+                            # Make dirty image
+                            self.task_make_test_dirty_image(clean_call=clean_call)
+                            result['status'] = 'completed'
+
+                        # Extract beam properties from PSF
+                        if not self._dry_run:
+                            beam_props = self._get_beam_properties(fname_dict['psf'])
+                            if beam_props:
+                                result.update(beam_props)
+
+                            # Extract image statistics
+                            img_stats = self._get_image_statistics(
+                                fname_dict['image'],
+                                pb_file=fname_dict['pb']
+                            )
+                            if img_stats:
+                                result.update(img_stats)
+
+                            # Compute PSF quality metrics via radial profile
+                            if os.path.isdir(fname_dict['psf']):
+                                bmaj = result.get('bmaj_arcsec')
+                                bmin = result.get('bmin_arcsec')
+                                if bmaj is not None and bmin is not None:
+                                    data_2d, pix_scale = tip._read_image_data(
+                                        fname_dict['psf'])
+                                    if data_2d is not None:
+                                        radii, psf_radial = tip._compute_radial_profile(
+                                            data_2d, pix_scale,
+                                            max_radius_arcsec=10.0 * bmaj)
+                                        del data_2d
+                                        result['kappa'] = tip.measure_kappa(
+                                            radii, psf_radial, bmaj, bmin)
+                                        result['skirt_level'] = tip.measure_skirt_level(
+                                            radii, psf_radial, bmaj, bmin)
+                                        result['epsilon'] = tip.measure_epsilon(
+                                            radii, psf_radial, bmaj, bmin)
+                                        # Cache radial profile for reuse in plotting
+                                        result['_psf_radii'] = radii
+                                        result['_psf_profile'] = psf_radial
+
+                        self._test_results.append(result)
+
+                        logger.info(
+                            f"Result: cell={result.get('cell_arcsec', 'N/A')} arcsec, "
+                            f"bmaj={result.get('bmaj_arcsec', 'N/A')} arcsec, "
+                            f"bmin={result.get('bmin_arcsec', 'N/A')} arcsec, "
+                            f"rms={result.get('rms', 'N/A')}, "
+                            f"kappa={result.get('kappa', 'N/A')}, "
+                            f"skirt={result.get('skirt_level', 'N/A')}, "
+                            f"epsilon={result.get('epsilon', 'N/A')}")
+
+            finally:
+                os.chdir(initial_dir)
+                logger.info(f"Restored working directory to {initial_dir}")
+
+            return self._test_results
+
+        #################
+        # get_results #
+        #################
+
+        def get_results(self):
+            """Return the list of test results."""
+            return self._test_results
+
+        ########################
+        # _get_unique_targets #
+        ########################
+
+        def _get_unique_targets(self, results):
+            """Return unique target names from results in order of first appearance."""
+            seen = set()
+            targets = []
+            for r in results:
+                t = r.get('target')
+                if t is not None and t not in seen:
+                    seen.add(t)
+                    targets.append(t)
+            return targets
+
+        ##################
+        # print_summary #
+        ##################
+
+        def print_summary(
+            self,
+            results=None,
+        ):
+            """
+            Print a summary table of test imaging results, grouped
+            by target.
+
+            Parameters
+            ----------
+            results : list, optional
+                List of result dictionaries. If None, uses stored results.
+            """
+            if results is None:
+                results = self._test_results
+
+            if len(results) == 0:
+                logger.warning("No results to summarize")
+                return
+
+            targets = self._get_unique_targets(results)
+
+            for this_target in targets:
+                target_results = [r for r in results
+                                  if r.get('target') == this_target]
+
+                print("")
+                print("=" * 160)
+                print(f"TEST IMAGING SUMMARY: {this_target}")
+                print("=" * 160)
+                print(f"{'Config':<12} {'Product':<10} {'Test':<20} "
+                      f"{'Cell':<8} {'Bmaj':<10} {'Bmin':<10} {'BPA':<8} {'RMS':<12} "
+                      f"{'Kappa':<10} {'Skirt':<10} {'epsilon':<10} {'Status':<10}")
+                print("-" * 160)
+
+                for r in target_results:
+                    cell = f"{r['cell_arcsec']:.4f}" if r.get('cell_arcsec') is not None else 'N/A'
+                    bmaj = f"{r.get('bmaj_arcsec', 0):.3f}" if r.get('bmaj_arcsec') else 'N/A'
+                    bmin = f"{r.get('bmin_arcsec', 0):.3f}" if r.get('bmin_arcsec') else 'N/A'
+                    bpa = f"{r.get('bpa_deg', 0):.1f}" if r.get('bpa_deg') else 'N/A'
+                    rms = f"{r.get('rms', 0):.2e}" if r.get('rms') else 'N/A'
+                    kappa = f"{r['kappa']:.4f}" if r.get('kappa') is not None else 'N/A'
+                    skirt = f"{r['skirt_level']:.4f}" if r.get('skirt_level') is not None else 'N/A'
+                    epsilon = f"{r['epsilon']:.4f}" if r.get('epsilon') is not None else 'N/A'
+
+                    print(f"{r.get('config', ''):<12} "
+                          f"{r.get('product', ''):<10} {r.get('test_name', ''):<20} "
+                          f"{cell:<8} {bmaj:<10} {bmin:<10} {bpa:<8} {rms:<12} "
+                          f"{kappa:<10} {skirt:<10} {epsilon:<10} "
+                          f"{r.get('status', ''):<10}")
+
+                print("=" * 160)
+                print("")
+
+        ######################
+        # export_summary_csv #
+        ######################
+
+        def export_summary_csv(
+            self,
+            filename='test_imaging_summary.csv',
+            results=None,
+        ):
+            """
+            Export test imaging results to per-target CSV files.
+
+            When results contain multiple targets, a separate CSV is
+            written for each target with the target name inserted into
+            the filename (e.g. ``test_imaging_summary_ngc3627.csv``).
+
+            Parameters
+            ----------
+            filename : str
+                Output CSV filename (or template for multi-target).
+            results : list, optional
+                List of result dictionaries. If None, uses stored results.
+            """
+            if results is None:
+                results = self._test_results
+
+            if len(results) == 0:
+                logger.warning("No results to export")
+                return
+
+            import csv
+
+            columns = ['target', 'config', 'product', 'test_name', 'weighting',
+                      'robust', 'taper_arcsec', 'cell_arcsec',
+                      'bmaj_arcsec', 'bmin_arcsec',
+                      'bpa_deg', 'max', 'min', 'rms', 'mean', 'median', 'npts',
+                      'kappa', 'skirt_level', 'epsilon', 'status']
+
+            targets = self._get_unique_targets(results)
+
+            for this_target in targets:
+                target_results = [r for r in results
+                                  if r.get('target') == this_target]
+
+                if len(targets) == 1:
+                    out_file = filename
+                else:
+                    base, ext = os.path.splitext(filename)
+                    out_file = f'{base}_{this_target}{ext}'
+
+                out_file = self._ensure_output_in_dir(
+                    out_file,
+                    self._resolve_imaging_dir(results, this_target))
+
+                with open(out_file, 'w', newline='') as csvfile:
+                    writer = csv.DictWriter(csvfile, fieldnames=columns,
+                                            extrasaction='ignore')
+                    writer.writeheader()
+                    for r in target_results:
+                        writer.writerow(r)
+
+                logger.info(f"Exported {len(target_results)} results for "
+                            f"{this_target} to {out_file}")
+
+        ####################
+        # suggest_optimal #
+        ####################
+
+        def suggest_optimal(
+            self,
+            target_resolution_arcsec=None,
+            results=None,
+        ):
+            """
+            Suggest the optimal imaging parameters for each target.
+
+            Parameters
+            ----------
+            target_resolution_arcsec : float, optional
+                Target resolution in arcseconds. If provided, suggests
+                parameters closest to this resolution.
+            results : list, optional
+                List of result dictionaries. If None, uses stored results.
+
+            Returns
+            -------
+            dict
+                Dictionary keyed by target name. Each value is the best
+                matching result dictionary for that target, or None if
+                no valid results exist.
+            """
+            if results is None:
+                results = self._test_results
+
+            if len(results) == 0:
+                logger.warning("No results to analyze")
+                return {}
+
+            targets = self._get_unique_targets(results)
+            recommendations = {}
+
+            for this_target in targets:
+                logger.info("")
+                logger.info(f"--- Recommendation for {this_target} ---")
+
+                valid_results = [r for r in results
+                                 if r.get('target') == this_target
+                                 and r.get('bmaj_arcsec') is not None]
+
+                if len(valid_results) == 0:
+                    logger.warning(f"  No valid results with beam measurements "
+                                   f"for {this_target}")
+                    recommendations[this_target] = None
+                    continue
+
+                if target_resolution_arcsec is not None:
+                    best = min(valid_results,
+                              key=lambda r: abs(r['bmaj_arcsec'] - target_resolution_arcsec))
+                    logger.info(f"  Closest to target resolution "
+                                f"{target_resolution_arcsec} arcsec:")
+                else:
+                    valid_with_rms = [r for r in valid_results
+                                      if r.get('rms') is not None]
+                    if len(valid_with_rms) > 0:
+                        best = min(valid_with_rms, key=lambda r: r['rms'])
+                        logger.info("  Best sensitivity (lowest RMS):")
+                    else:
+                        best = min(valid_results, key=lambda r: r['bmaj_arcsec'])
+                        logger.info("  Highest resolution:")
+
+                logger.info(f"  Test: {best['test_name']}")
+                logger.info(f"  Weighting: {best['weighting']}, "
+                            f"Robust: {best.get('robust')}")
+                logger.info(f"  Taper: {best['taper_arcsec']} arcsec")
+                logger.info(f"  Beam: {best['bmaj_arcsec']:.3f} x "
+                            f"{best['bmin_arcsec']:.3f} arcsec")
+                if best.get('rms'):
+                    logger.info(f"  RMS: {best['rms']:.2e}")
+
+                recommendations[this_target] = best
+
+            return recommendations
+
+        ##############################
+        # plot_psf_radial_profiles #
+        ##############################
+
+        def plot_psf_radial_profiles(
+            self,
+            target=None,
+            config=None,
+            product=None,
+            output_file='psf_radial_profiles.png',
+            results=None,
+            imaging_dir=None,
+            max_radius_arcsec=None,
+            bin_width_arcsec=None,
+            log_scale=False,
+            figsize=None,
+            dpi=150,
+            title=None,
+        ):
+            """
+            Plot 1D radial PSF profiles, produced separately per target.
+
+            When ``target`` is None, a separate figure is created for
+            each target in the results, with the target name inserted
+            into the output filename.
+
+            Parameters
+            ----------
+            target : str, optional
+                Restrict to this target. If None, loops over all targets.
+            config : str, optional
+                Filter results to this config.
+            product : str, optional
+                Filter results to this product.
+            output_file : str, optional
+                Output filename (template for multi-target).
+            results : list, optional
+                List of result dictionaries. If None, uses stored results.
+            imaging_dir : str, optional
+                Directory containing test images. If None, resolved from
+                the key handler per target.
+            max_radius_arcsec : float, optional
+                Maximum radius for the profile.
+            bin_width_arcsec : float, optional
+                Radial bin width in arcseconds. Enforced to be at least
+                one pixel wide. If None, defaults to one pixel.
+            log_scale : bool
+                Use symlog y-axis scale.
+            figsize : tuple, optional
+                Figure size in inches.
+            dpi : int
+                Figure resolution.
+            title : str, optional
+                Figure title.
+
+            Returns
+            -------
+            dict
+                Dictionary mapping target name to matplotlib Figure.
+            """
+            if results is None:
+                results = self._test_results
+
+            if len(results) == 0:
+                logger.warning("No results to plot")
+                return {}
+
+            targets = [target] if target else self._get_unique_targets(results)
+            all_figs = {}
+
+            for this_target in targets:
+                this_imaging_dir = imaging_dir
+                if this_imaging_dir is None:
+                    this_imaging_dir = self._resolve_imaging_dir(
+                        results, this_target)
+
+                this_output = self._per_target_filename(
+                    output_file, this_target, len(targets))
+                this_output = self._ensure_output_in_dir(
+                    this_output, this_imaging_dir)
+
+                fig = tip.make_psf_radial_profile_gallery(
+                    results=results,
+                    imaging_dir=this_imaging_dir,
+                    output_file=this_output,
+                    target=this_target,
+                    config=config,
+                    product=product,
+                    max_radius_arcsec=max_radius_arcsec,
+                    bin_width_arcsec=bin_width_arcsec,
+                    log_scale=log_scale,
+                    figsize=figsize,
+                    dpi=dpi,
+                    title=title,
+                )
+                all_figs[this_target] = fig
+
+            return all_figs
+
+        #####################
+        # plot_psf_gallery #
+        #####################
+
+        def plot_psf_gallery(
+            self,
+            target=None,
+            config=None,
+            product=None,
+            output_file='psf_image_gallery.png',
+            results=None,
+            imaging_dir=None,
+            zoom_radius_arcsec=None,
+            vmin=-0.1,
+            vmax=1.0,
+            cmap='RdBu_r',
+            show_beam_ellipse=True,
+            max_panels_per_page=9,
+            figsize=None,
+            dpi=150,
+            title=None,
+        ):
+            """
+            Plot a gallery of 2D PSF images, produced separately per
+            target. Automatically splits into multiple pages per target
+            if there are more results than max_panels_per_page.
+
+            Parameters
+            ----------
+            target : str, optional
+                Restrict to this target. If None, loops over all targets.
+            config : str, optional
+                Filter results to this config.
+            product : str, optional
+                Filter results to this product.
+            output_file : str, optional
+                Output filename (template for multi-target/multi-page).
+            results : list, optional
+                List of result dictionaries. If None, uses stored results.
+            imaging_dir : str, optional
+                Directory containing test images. If None, resolved from
+                the key handler per target.
+            zoom_radius_arcsec : float, optional
+                Half-width of the zoomed region in arcseconds.
+            vmin : float
+                Minimum color scale value.
+            vmax : float
+                Maximum color scale value.
+            cmap : str
+                Matplotlib colormap name.
+            show_beam_ellipse : bool
+                Draw beam ellipses on each panel.
+            max_panels_per_page : int
+                Maximum panels per figure page (default 9).
+            figsize : tuple, optional
+                Figure size in inches.
+            dpi : int
+                Figure resolution.
+            title : str, optional
+                Figure supertitle.
+
+            Returns
+            -------
+            dict
+                Dictionary mapping target name to list of Figures.
+            """
+            if results is None:
+                results = self._test_results
+
+            if len(results) == 0:
+                logger.warning("No results to plot")
+                return {}
+
+            targets = [target] if target else self._get_unique_targets(results)
+            all_figs = {}
+
+            for this_target in targets:
+                this_imaging_dir = imaging_dir
+                if this_imaging_dir is None:
+                    this_imaging_dir = self._resolve_imaging_dir(
+                        results, this_target)
+
+                this_output = self._per_target_filename(
+                    output_file, this_target, len(targets))
+                this_output = self._ensure_output_in_dir(
+                    this_output, this_imaging_dir)
+
+                figs = tip.make_psf_image_gallery(
+                    results=results,
+                    imaging_dir=this_imaging_dir,
+                    output_file=this_output,
+                    target=this_target,
+                    config=config,
+                    product=product,
+                    zoom_radius_arcsec=zoom_radius_arcsec,
+                    vmin=vmin,
+                    vmax=vmax,
+                    cmap=cmap,
+                    show_beam_ellipse=show_beam_ellipse,
+                    max_panels_per_page=max_panels_per_page,
+                    figsize=figsize,
+                    dpi=dpi,
+                    title=title,
+                )
+                all_figs[this_target] = figs
+
+            return all_figs
+
+        #######################
+        # plot_image_gallery #
+        #######################
+
+        def plot_image_gallery(
+            self,
+            target=None,
+            config=None,
+            product=None,
+            output_file='image_gallery.png',
+            results=None,
+            imaging_dir=None,
+            zoom_radius_arcsec=None,
+            vmin=None,
+            vmax=None,
+            cmap='inferno',
+            show_beam_ellipse=True,
+            symmetric_color=False,
+            sigma_clip=3.0,
+            max_panels_per_page=9,
+            figsize=None,
+            dpi=150,
+            title=None,
+        ):
+            """
+            Plot a gallery of 2D dirty images, produced separately per
+            target. Automatically splits into multiple pages per target
+            if there are more results than max_panels_per_page.
+
+            Parameters
+            ----------
+            target : str, optional
+                Restrict to this target. If None, loops over all targets.
+            config : str, optional
+                Filter results to this config.
+            product : str, optional
+                Filter results to this product.
+            output_file : str, optional
+                Output filename (template for multi-target/multi-page).
+            results : list, optional
+                List of result dictionaries. If None, uses stored results.
+            imaging_dir : str, optional
+                Directory containing test images. If None, resolved from
+                the key handler per target.
+            zoom_radius_arcsec : float, optional
+                Half-width of the displayed region in arcseconds.
+            vmin : float, optional
+                Minimum color scale value.
+            vmax : float, optional
+                Maximum color scale value.
+            cmap : str
+                Matplotlib colormap name.
+            show_beam_ellipse : bool
+                Draw beam ellipses on each panel.
+            symmetric_color : bool
+                Use symmetric color range centered on zero.
+            sigma_clip : float
+                Sigma level for auto color range.
+            max_panels_per_page : int
+                Maximum panels per figure page (default 9).
+            figsize : tuple, optional
+                Figure size in inches.
+            dpi : int
+                Figure resolution.
+            title : str, optional
+                Figure supertitle.
+
+            Returns
+            -------
+            dict
+                Dictionary mapping target name to list of Figures.
+            """
+            if results is None:
+                results = self._test_results
+
+            if len(results) == 0:
+                logger.warning("No results to plot")
+                return {}
+
+            targets = [target] if target else self._get_unique_targets(results)
+            all_figs = {}
+
+            for this_target in targets:
+                this_imaging_dir = imaging_dir
+                if this_imaging_dir is None:
+                    this_imaging_dir = self._resolve_imaging_dir(
+                        results, this_target)
+
+                this_output = self._per_target_filename(
+                    output_file, this_target, len(targets))
+                this_output = self._ensure_output_in_dir(
+                    this_output, this_imaging_dir)
+
+                figs = tip.make_image_gallery(
+                    results=results,
+                    imaging_dir=this_imaging_dir,
+                    output_file=this_output,
+                    target=this_target,
+                    config=config,
+                    product=product,
+                    zoom_radius_arcsec=zoom_radius_arcsec,
+                    vmin=vmin,
+                    vmax=vmax,
+                    cmap=cmap,
+                    show_beam_ellipse=show_beam_ellipse,
+                    symmetric_color=symmetric_color,
+                    sigma_clip=sigma_clip,
+                    max_panels_per_page=max_panels_per_page,
+                    figsize=figsize,
+                    dpi=dpi,
+                    title=title,
+                )
+                all_figs[this_target] = figs
+
+            return all_figs
+
+        ##############################
+        # plot_metrics_vs_robust    #
+        ##############################
+
+        def plot_metrics_vs_robust(
+            self,
+            target=None,
+            config=None,
+            product=None,
+            output_file='metrics_vs_robust.png',
+            results=None,
+            imaging_dir=None,
+            metrics=None,
+            figsize=None,
+            dpi=150,
+            title=None,
+        ):
+            """
+            Plot imaging metrics as a function of the robust parameter,
+            produced separately per target.
+
+            Default panels: beam major axis, RMS, kappa, epsilon, and skirt
+            level.
+
+            Parameters
+            ----------
+            target : str, optional
+                Restrict to this target. If None, loops over all targets.
+            config : str, optional
+                Filter results to this config.
+            product : str, optional
+                Filter results to this product.
+            output_file : str, optional
+                Output filename (template for multi-target).
+            results : list, optional
+                List of result dictionaries. If None, uses stored results.
+            imaging_dir : str, optional
+                Directory for output. If None, resolved from the key
+                handler per target.
+            metrics : list of tuple, optional
+                List of ``(result_key, y_label)`` pairs. Defaults to
+                bmaj, rms, kappa, epsilon, skirt_level.
+            figsize : tuple, optional
+                Figure size in inches.
+            dpi : int
+                Figure resolution.
+            title : str, optional
+                Figure super-title.
+
+            Returns
+            -------
+            dict
+                Dictionary mapping target name to matplotlib Figure.
+            """
+            if results is None:
+                results = self._test_results
+
+            if len(results) == 0:
+                logger.warning("No results to plot")
+                return {}
+
+            targets = [target] if target else self._get_unique_targets(results)
+            all_figs = {}
+
+            for this_target in targets:
+                this_imaging_dir = imaging_dir
+                if this_imaging_dir is None:
+                    this_imaging_dir = self._resolve_imaging_dir(
+                        results, this_target)
+
+                this_output = self._per_target_filename(
+                    output_file, this_target, len(targets))
+                this_output = self._ensure_output_in_dir(
+                    this_output, this_imaging_dir)
+
+                fig = tip.make_metrics_vs_robust_gallery(
+                    results=results,
+                    output_file=this_output,
+                    target=this_target,
+                    config=config,
+                    product=product,
+                    metrics=metrics,
+                    figsize=figsize,
+                    dpi=dpi,
+                    title=title,
+                )
+                all_figs[this_target] = fig
+
+            return all_figs
+
+        ############################
+        # plot_metrics_vs_beam    #
+        ############################
+
+        def plot_metrics_vs_beam(
+            self,
+            target=None,
+            config=None,
+            product=None,
+            output_file='metrics_vs_beam.png',
+            results=None,
+            imaging_dir=None,
+            metrics=None,
+            figsize=None,
+            dpi=150,
+            title=None,
+        ):
+            """
+            Plot imaging metrics as a function of beam size, produced
+            separately per target.
+
+            All weighting schemes and taper values are shown together
+            on each panel, distinguished by colour and marker.
+            Default panels: RMS, kappa, epsilon, and skirt level.
+
+            Parameters
+            ----------
+            target : str, optional
+                Restrict to this target. If None, loops over all targets.
+            config : str, optional
+                Filter results to this config.
+            product : str, optional
+                Filter results to this product.
+            output_file : str, optional
+                Output filename (template for multi-target).
+            results : list, optional
+                List of result dictionaries. If None, uses stored results.
+            imaging_dir : str, optional
+                Directory for output. If None, resolved from the key
+                handler per target.
+            metrics : list of tuple, optional
+                List of ``(result_key, y_label)`` pairs.
+            figsize : tuple, optional
+                Figure size in inches.
+            dpi : int
+                Figure resolution.
+            title : str, optional
+                Figure super-title.
+
+            Returns
+            -------
+            dict
+                Dictionary mapping target name to matplotlib Figure.
+            """
+            if results is None:
+                results = self._test_results
+
+            if len(results) == 0:
+                logger.warning("No results to plot")
+                return {}
+
+            targets = [target] if target else self._get_unique_targets(results)
+            all_figs = {}
+
+            for this_target in targets:
+                this_imaging_dir = imaging_dir
+                if this_imaging_dir is None:
+                    this_imaging_dir = self._resolve_imaging_dir(
+                        results, this_target)
+
+                this_output = self._per_target_filename(
+                    output_file, this_target, len(targets))
+                this_output = self._ensure_output_in_dir(
+                    this_output, this_imaging_dir)
+
+                fig = tip.make_metrics_vs_beam_gallery(
+                    results=results,
+                    output_file=this_output,
+                    target=this_target,
+                    config=config,
+                    product=product,
+                    metrics=metrics,
+                    figsize=figsize,
+                    dpi=dpi,
+                    title=title,
+                )
+                all_figs[this_target] = fig
+
+            return all_figs
+
+        #################
+        # make_report #
+        #################
+
+        def make_report(
+            self,
+            output_prefix='test_imaging',
+            output_dir=None,
+            config=None,
+            product=None,
+            results=None,
+            plots=None,
+            plot_kwargs=None,
+            dpi=150,
+        ):
+            """
+            Generate a full diagnostic report per target.
+
+            Loops over each target in the results and produces a
+            separate set of outputs (CSV, plots, recommendation) for
+            each one. The set of outputs is controlled by the ``plots``
+            parameter and can be extended by adding new entries to the
+            internal registry.
+
+            Parameters
+            ----------
+            output_prefix : str
+                Prefix for all output filenames. When there are multiple
+                targets the target name is appended automatically
+                (e.g. ``'test_imaging'`` -> ``'test_imaging_ngc3627_psf_profiles.png'``).
+                With a single target, the prefix is used as-is
+                (e.g. ``'test_imaging'`` -> ``'test_imaging_psf_profiles.png'``).
+            output_dir : str, optional
+                Directory for output files. If None, uses the imaging
+                directory for each target.
+            config : str, optional
+                Filter results to this config.
+            product : str, optional
+                Filter results to this product.
+            results : list, optional
+                List of result dictionaries. If None, uses stored results.
+            plots : list of str, optional
+                Which outputs to produce. Supported keys:
+
+                - ``'csv'`` : summary CSV table
+                - ``'psf_profiles'`` : 1D radial PSF profiles
+                - ``'psf_gallery'`` : 2D PSF image grid
+                - ``'image_gallery'`` : 2D dirty image grid
+                - ``'metrics_vs_robust'`` : metrics vs. robust parameter
+                - ``'metrics_vs_beam'`` : metrics vs. beam size
+                - ``'html'`` : self-contained HTML summary report
+
+                If None, all of the above are produced.
+            plot_kwargs : dict, optional
+                Per-plot keyword overrides. Keys are the plot names from
+                the ``plots`` list; values are dicts of keyword arguments
+                passed to the corresponding method. For example::
+
+                    plot_kwargs={
+                        'psf_gallery': {'zoom_radius_arcsec': 5.0},
+                        'psf_profiles': {'log_scale': True},
+                    }
+            dpi : int
+                Default figure resolution for all plots.
+
+            Returns
+            -------
+            dict
+                Dictionary keyed by target name. Each value is a dict
+                mapping output keys (e.g. ``'csv'``, ``'psf_gallery'``)
+                to their results.
+            """
+            if results is None:
+                results = self._test_results
+
+            if len(results) == 0:
+                logger.warning("No results for report")
+                return {}
+
+            if plots is None:
+                plots = ['csv', 'psf_profiles', 'psf_gallery',
+                         'image_gallery', 'metrics_vs_robust',
+                         'metrics_vs_beam', 'html']
+
+            if plot_kwargs is None:
+                plot_kwargs = {}
+
+            targets = self._get_unique_targets(results)
+            all_reports = {}
+
+            for this_target in targets:
+                logger.info("")
+                logger.info("=" * 60)
+                logger.info(f"REPORT: {this_target}")
+                logger.info("=" * 60)
+
+                target_results = [r for r in results
+                                  if r.get('target') == this_target]
+
+                imaging_dir = self._resolve_imaging_dir(
+                    target_results, this_target)
+
+                this_output_dir = output_dir if output_dir is not None else imaging_dir
+                if len(targets) > 1:
+                    prefix = output_prefix + '_' + this_target
+                else:
+                    prefix = output_prefix
+
+                def _out(suffix):
+                    return os.path.join(this_output_dir, prefix + '_' + suffix)
+
+                # Registry of report outputs.
+                # Extend this dict to add new report outputs.
+                registry = {
+                    'csv': {
+                        'method': self.export_summary_csv,
+                        'output_file': _out('summary.csv'),
+                        'default_kwargs': {},
+                        'output_key': 'filename',
+                    },
+                    'psf_profiles': {
+                        'method': self.plot_psf_radial_profiles,
+                        'output_file': _out('psf_profiles.png'),
+                        'default_kwargs': {},
+                        'output_key': 'output_file',
+                    },
+                    'psf_gallery': {
+                        'method': self.plot_psf_gallery,
+                        'output_file': _out('psf_gallery.png'),
+                        'default_kwargs': {},
+                        'output_key': 'output_file',
+                    },
+                    'image_gallery': {
+                        'method': self.plot_image_gallery,
+                        'output_file': _out('image_gallery.png'),
+                        'default_kwargs': {},
+                        'output_key': 'output_file',
+                    },
+                    'metrics_vs_robust': {
+                        'method': self.plot_metrics_vs_robust,
+                        'output_file': _out('metrics_vs_robust.png'),
+                        'default_kwargs': {},
+                        'output_key': 'output_file',
+                    },
+                    'metrics_vs_beam': {
+                        'method': self.plot_metrics_vs_beam,
+                        'output_file': _out('metrics_vs_beam.png'),
+                        'default_kwargs': {},
+                        'output_key': 'output_file',
+                    },
+                }
+
+                report = {}
+
+                for key in plots:
+                    # HTML report is generated last, after all plots
+                    if key == 'html':
+                        continue
+
+                    if key not in registry:
+                        logger.warning(f"Unknown report output: '{key}', "
+                                       f"skipping")
+                        continue
+
+                    entry = registry[key]
+                    kwargs = dict(entry['default_kwargs'])
+                    kwargs.update(plot_kwargs.get(key, {}))
+
+                    kwargs[entry['output_key']] = kwargs.get(
+                        entry['output_key'], entry['output_file'])
+
+                    if key == 'csv':
+                        kwargs.setdefault('results', target_results)
+                    else:
+                        kwargs.setdefault('results', target_results)
+                        kwargs.setdefault('imaging_dir', imaging_dir)
+                        kwargs.setdefault('target', this_target)
+                        kwargs.setdefault('config', config)
+                        kwargs.setdefault('product', product)
+                        kwargs.setdefault('dpi', dpi)
+
+                    try:
+                        result = entry['method'](**kwargs)
+                        report[key] = result
+                        logger.info(f"  {this_target}: produced '{key}' -> "
+                                    f"{kwargs[entry['output_key']]}")
+                        # Close figures immediately after saving to free memory
+                        self._close_figures(result)
+                    except Exception as e:
+                        logger.error(f"  {this_target}: failed '{key}': {e}")
+                        report[key] = None
+
+                # Generate HTML report last so it can embed all plots
+                if 'html' in plots:
+                    html_file = _out('report.html')
+                    plot_files = self._collect_plot_files(
+                        report, registry)
+                    try:
+                        tip.make_html_report(
+                            results=target_results,
+                            plot_files=plot_files,
+                            output_file=html_file,
+                            target=this_target,
+                        )
+                        report['html'] = html_file
+                        logger.info(f"  {this_target}: produced 'html' -> "
+                                    f"{html_file}")
+                    except Exception as e:
+                        logger.error(f"  {this_target}: failed 'html': {e}")
+                        report['html'] = None
+
+                all_reports[this_target] = report
+
+            return all_reports
+
+        ###########################
+        # _collect_plot_files    #
+        ###########################
+
+        def _collect_plot_files(self, report, registry):
+            """Collect output plot file paths from a report dict.
+
+            Walks the report dict produced by ``make_report`` and
+            extracts file paths for each generated plot, suitable for
+            passing to ``make_html_report``.
+
+            All plot methods return ``{target: fig}`` or
+            ``{target: [fig, ...]}``; this method unwraps those dicts
+            and uses the figure-list length to determine how many
+            paginated files (``_1.png``, ``_2.png``, ...) were written.
+
+            Parameters
+            ----------
+            report : dict
+                Per-target report dict mapping keys to results.
+            registry : dict
+                The registry dict from ``make_report``.
+
+            Returns
+            -------
+            dict
+                Mapping of plot key to file path (str) or list of paths.
+            """
+            plot_files = {}
+            for key, value in report.items():
+                if key in ('csv', 'html') or value is None:
+                    continue
+                entry = registry.get(key, {})
+                out_file = entry.get('output_file')
+                if out_file is None:
+                    continue
+
+                # All plot methods return {target: fig} or {target: [figs]}.
+                # Unwrap the per-target dict to get the actual figure(s).
+                inner = value
+                if isinstance(inner, dict):
+                    vals = list(inner.values())
+                    inner = vals[0] if len(vals) == 1 else None
+
+                if inner is None:
+                    continue
+
+                # Use the figure list length to determine how many pages
+                # were produced (works even after figures are closed).
+                n_pages = len(inner) if isinstance(inner, list) else 1
+
+                if n_pages > 1:
+                    # Multi-page gallery: look for _1.png, _2.png, ...
+                    base, ext = os.path.splitext(out_file)
+                    files = []
+                    for i in range(n_pages):
+                        candidate = f'{base}_{i + 1}{ext}'
+                        if os.path.isfile(candidate):
+                            files.append(candidate)
+                    if files:
+                        plot_files[key] = files
+                elif os.path.isfile(out_file):
+                    plot_files[key] = out_file
+
+            return plot_files
+
+        ####################
+        # _close_figures #
+        ####################
+
+        def _close_figures(self, obj):
+            """Recursively close matplotlib Figure objects to free memory.
+
+            Handles the nested dict/list structures returned by the plot
+            methods so that ``make_report`` can free each figure as soon
+            as it has been saved to disk.
+            """
+            if obj is None:
+                return
+            if isinstance(obj, dict):
+                for v in obj.values():
+                    self._close_figures(v)
+            elif isinstance(obj, list):
+                for v in obj:
+                    self._close_figures(v)
+            elif hasattr(obj, 'savefig'):
+                try:
+                    import matplotlib.pyplot as plt
+                    plt.close(obj)
+                except Exception:
+                    pass
+
+        ###########################
+        # _per_target_filename #
+        ###########################
+
+        def _per_target_filename(self, output_file, target, n_targets):
+            """
+            Insert the target name into an output filename when there
+            are multiple targets.
+
+            Parameters
+            ----------
+            output_file : str or None
+                Base output filename.
+            target : str
+                Target name.
+            n_targets : int
+                Total number of targets being processed.
+
+            Returns
+            -------
+            str or None
+            """
+            if output_file is None:
+                return None
+            if n_targets <= 1:
+                return output_file
+            base, ext = os.path.splitext(output_file)
+            return f'{base}_{target}{ext}'
+
+        ############################
+        # _ensure_output_in_dir #
+        ############################
+
+        def _ensure_output_in_dir(self, output_file, directory):
+            """
+            If *output_file* is a bare filename (no directory component),
+            join it with *directory* so products are saved in the imaging
+            directory by default.
+
+            Parameters
+            ----------
+            output_file : str or None
+                Output filename. If None, returned as-is.
+            directory : str or None
+                Directory to prepend. If None, no change is made.
+
+            Returns
+            -------
+            str or None
+            """
+            if output_file is None or directory is None:
+                return output_file
+            if os.path.dirname(output_file):
+                # Already has a directory component — respect it
+                return output_file
+            return os.path.join(directory, output_file)
+
+        ##########################
+        # _resolve_imaging_dir #
+        ##########################
+
+        def _resolve_imaging_dir(
+            self,
+            results,
+            target=None,
+        ):
+            """
+            Resolve the imaging directory from the key handler.
+
+            Uses the provided target name, or falls back to the target
+            from the first result entry.
+
+            Parameters
+            ----------
+            results : list of dict
+                Results list.
+            target : str, optional
+                Target name to look up.
+
+            Returns
+            -------
+            str
+                Path to the imaging directory.
+            """
+            if target is None and len(results) > 0:
+                target = results[0].get('target')
+
+            if target is not None and self._kh is not None:
+                try:
+                    return self._kh.get_imaging_dir_for_target(target=target)
+                except Exception as e:
+                    logger.warning(f"Could not resolve imaging dir for {target}: {e}")
+
+            return '.'

--- a/phangsPipeline/utilsTestImagingPlots.py
+++ b/phangsPipeline/utilsTestImagingPlots.py
@@ -1,0 +1,1807 @@
+"""utilsTestImagingPlots
+
+Utility functions for creating diagnostic plots from test imaging results.
+Creates 1D radial PSF profile galleries, 2D PSF image galleries, and
+2D dirty image galleries for comparing different imaging parameters.
+
+These functions work with the results list produced by
+TestImagingHandler.get_results().
+
+This module requires matplotlib and numpy. It can read CASA images
+(when running inside CASA) or FITS files (via astropy).
+
+Example:
+    from phangsPipeline import handlerTestImaging as tih
+    from phangsPipeline import utilsTestImagingPlots as tip
+
+    # After running test imaging:
+    results = this_tih.get_results()
+
+    # Create galleries
+    tip.make_psf_radial_profile_gallery(
+        results, imaging_dir='/path/to/imaging/',
+        output_file='psf_profiles.png')
+
+    tip.make_psf_image_gallery(
+        results, imaging_dir='/path/to/imaging/',
+        output_file='psf_gallery.png')
+
+    tip.make_image_gallery(
+        results, imaging_dir='/path/to/imaging/',
+        output_file='image_gallery.png')
+"""
+
+import os
+import logging
+import math
+import base64
+from datetime import datetime
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+try:
+    import matplotlib
+    matplotlib.use('Agg')
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import Ellipse
+    HAS_MATPLOTLIB = True
+except ImportError:
+    HAS_MATPLOTLIB = False
+    logger.warning("matplotlib not available, plotting functions will not work")
+
+try:
+    from astropy.io import fits
+    HAS_ASTROPY = True
+except ImportError:
+    HAS_ASTROPY = False
+
+from .casa_check import is_casa_installed
+casa_enabled = is_casa_installed()
+
+if casa_enabled:
+    import analysisUtils as au
+    from . import casaStuff
+
+from . import utilsFilenames
+
+
+
+import os
+
+from scipy.interpolate import UnivariateSpline
+
+
+fwhm_factor = 2 * np.sqrt(2 * np.log(2))  # FWHM to sigma conversion factor
+
+
+
+# ---------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------
+
+
+def _read_image_data(image_file):
+    """Read 2D image data from a CASA image or FITS file.
+
+    Tries CASA image tools first (if available), then falls back to
+    astropy FITS reading. Squeezes any degenerate axes to return a
+    2D array.
+
+    Parameters
+    ----------
+    image_file : str
+        Path to a CASA image directory or a FITS file.
+
+    Returns
+    -------
+    data_2d : numpy.ndarray or None
+        2D image data array (y, x ordering for matplotlib).
+    pixel_scale_arcsec : float or None
+        Pixel scale in arcseconds.
+    """
+    if image_file is None:
+        return None, None
+
+    # Try CASA image
+    if casa_enabled and os.path.isdir(image_file):
+        try:
+            myia = au.createCasaTool(casaStuff.iatool)
+            myia.open(image_file)
+            data = myia.getchunk()
+            csys = myia.coordsys()
+            increments = csys.increment()['numeric']
+            # RA increment is in radians; take absolute value
+            pixel_scale_arcsec = abs(increments[0]) * 206264.806
+            myia.close()
+            # Squeeze degenerate axes (Stokes, Freq) to get 2D
+            data_2d = np.squeeze(data)
+            if data_2d.ndim != 2:
+                logger.warning(f"Image has {data_2d.ndim} dimensions after squeeze, "
+                               f"expected 2: {image_file}")
+                return None, None
+            # CASA images are (x, y) order; transpose for matplotlib (y, x)
+            data_2d = data_2d.T
+            return data_2d, pixel_scale_arcsec
+        except Exception as e:
+            logger.warning(f"Failed to read CASA image {image_file}: {e}")
+
+    # Try FITS file
+    fits_file = image_file
+    if not fits_file.endswith('.fits'):
+        fits_file = image_file + '.fits'
+    if HAS_ASTROPY and os.path.isfile(fits_file):
+        try:
+            hdu = fits.open(fits_file)[0]
+            data_2d = np.squeeze(hdu.data)
+            if data_2d.ndim != 2:
+                logger.warning(f"FITS image has {data_2d.ndim} dimensions after squeeze: "
+                               f"{fits_file}")
+                return None, None
+            # Pixel scale from CDELT2 (Dec axis), in degrees -> arcsec
+            pixel_scale_arcsec = abs(hdu.header.get('CDELT2', 1.0)) * 3600.0
+            return data_2d, pixel_scale_arcsec
+        except Exception as e:
+            logger.warning(f"Failed to read FITS file {fits_file}: {e}")
+
+    logger.warning(f"Could not read image: {image_file}")
+    return None, None
+
+
+def _compute_radial_profile(data_2d, pixel_scale_arcsec, center=None,
+                            max_radius_arcsec=None, bin_width_arcsec=None):
+    """Compute an azimuthally averaged radial profile of a 2D image.
+
+    Parameters
+    ----------
+    data_2d : numpy.ndarray
+        2D image array.
+    pixel_scale_arcsec : float
+        Pixel scale in arcseconds.
+    center : tuple of int, optional
+        (y, x) center pixel. If None, uses the peak pixel.
+    max_radius_arcsec : float, optional
+        Maximum radius to compute the profile out to. If None, extends
+        to the shorter image half-dimension.
+    bin_width_arcsec : float, optional
+        Radial bin width in arcseconds. The actual width used is
+        ``max(bin_width_arcsec, pixel_scale_arcsec)`` so that each bin
+        is at least one pixel wide and never empty due to under-sampling.
+        If None, defaults to one pixel (``pixel_scale_arcsec``).
+
+    Returns
+    -------
+    radius_arcsec : numpy.ndarray
+        Bin centers in arcseconds.
+    profile : numpy.ndarray
+        Azimuthally averaged profile values.
+    """
+    ny, nx = data_2d.shape
+
+    if center is None:
+        # Find peak pixel
+        peak_idx = np.unravel_index(np.nanargmax(data_2d), data_2d.shape)
+        cy, cx = peak_idx
+    else:
+        cy, cx = center
+
+    # Build distance array in arcsec
+    y_arr, x_arr = np.mgrid[0:ny, 0:nx]
+    dist_pix = np.sqrt((x_arr - cx)**2 + (y_arr - cy)**2)
+    dist_arcsec = dist_pix * pixel_scale_arcsec
+
+    # Determine max radius
+    if max_radius_arcsec is None:
+        max_radius_pix = min(cx, cy, nx - cx - 1, ny - cy - 1)
+        max_radius_arcsec = max_radius_pix * pixel_scale_arcsec
+
+    # Enforce minimum bin width of one pixel
+    if bin_width_arcsec is None:
+        bin_width_arcsec = pixel_scale_arcsec
+    else:
+        bin_width_arcsec = max(bin_width_arcsec, pixel_scale_arcsec)
+
+    n_bins = max(1, int(np.ceil(max_radius_arcsec / bin_width_arcsec)))
+
+    # Create radial bins
+    bin_edges = np.linspace(0, max_radius_arcsec, n_bins + 1)
+    bin_centers = 0.5 * (bin_edges[:-1] + bin_edges[1:])
+    profile = np.zeros(n_bins)
+
+    for i in range(n_bins):
+        mask = (dist_arcsec >= bin_edges[i]) & (dist_arcsec < bin_edges[i + 1])
+        if np.any(mask):
+            profile[i] = np.nanmean(data_2d[mask])
+        else:
+            profile[i] = np.nan
+
+    return bin_centers, profile
+
+
+def _build_image_root(result):
+    """Reconstruct the image root filename from a result dictionary.
+
+    Parameters
+    ----------
+    result : dict
+        A result dictionary from TestImagingHandler.get_results().
+
+    Returns
+    -------
+    str
+        The image root path (without CASA extension like .psf or .image).
+    """
+    return utilsFilenames.get_cube_filename(
+        target=result['target'],
+        product=result['product'],
+        config=result['config'],
+        ext='test_' + result['test_name'],
+        casa=True,
+        casaext='',
+    )
+
+
+def _get_grid_layout(n_panels):
+    """Compute a grid layout (nrows, ncols) for n_panels.
+
+    Parameters
+    ----------
+    n_panels : int
+        Number of panels.
+
+    Returns
+    -------
+    nrows : int
+    ncols : int
+    """
+    if n_panels <= 0:
+        return 0, 0
+    ncols = math.ceil(math.sqrt(n_panels))
+    nrows = math.ceil(n_panels / ncols)
+    return nrows, ncols
+
+
+def _filter_results(results, target=None, config=None, product=None):
+    """Filter results list by target, config, and/or product.
+
+    Parameters
+    ----------
+    results : list of dict
+        Results from TestImagingHandler.get_results().
+    target : str, optional
+        Filter to this target only.
+    config : str, optional
+        Filter to this config only.
+    product : str, optional
+        Filter to this product only.
+
+    Returns
+    -------
+    list of dict
+        Filtered results.
+    """
+    filtered = results
+    if target is not None:
+        filtered = [r for r in filtered if r.get('target') == target]
+    if config is not None:
+        filtered = [r for r in filtered if r.get('config') == config]
+    if product is not None:
+        filtered = [r for r in filtered if r.get('product') == product]
+    return filtered
+
+
+def _get_max_beam_arcsec(results):
+    """Return the largest beam major axis from a list of results.
+
+    Parameters
+    ----------
+    results : list of dict
+        Filtered results list.
+
+    Returns
+    -------
+    float or None
+        Largest bmaj_arcsec, or None if no valid beams.
+    """
+    bmajs = [r['bmaj_arcsec'] for r in results
+             if r.get('bmaj_arcsec') is not None]
+    if len(bmajs) == 0:
+        return None
+    return max(bmajs)
+
+
+def _paginated_output_file(output_file, page_idx, n_pages):
+    """Generate an enumerated output filename for multi-page galleries.
+
+    Parameters
+    ----------
+    output_file : str or None
+        Base output filename.
+    page_idx : int
+        Zero-based page index.
+    n_pages : int
+        Total number of pages.
+
+    Returns
+    -------
+    str or None
+        For a single page, returns the original filename unchanged.
+        For multiple pages, inserts ``_N`` before the extension
+        (e.g. ``gallery.png`` -> ``gallery_1.png``, ``gallery_2.png``).
+    """
+    if output_file is None:
+        return None
+    if n_pages <= 1:
+        return output_file
+    base, ext = os.path.splitext(output_file)
+    return f'{base}_{page_idx + 1}{ext}'
+
+
+def _make_label(result):
+    """Build a concise label string from a result dictionary.
+
+    Parameters
+    ----------
+    result : dict
+        A single result dictionary.
+
+    Returns
+    -------
+    str
+        Label string, e.g. "briggs_r0.5 (1.23x0.98 arcsec)".
+    """
+    label = result.get('test_name', '?')
+    bmaj = result.get('bmaj_arcsec')
+    bmin = result.get('bmin_arcsec')
+    if bmaj is not None and bmin is not None:
+        label += f' ({bmaj:.2f}x{bmin:.2f}")'
+    return label
+
+
+# ---------------------------------------------------------------
+# Public gallery functions
+# ---------------------------------------------------------------
+
+
+def make_psf_radial_profile_gallery(
+    results,
+    imaging_dir=None,
+    output_file=None,
+    target=None,
+    config=None,
+    product=None,
+    max_radius_arcsec=None,
+    bin_width_arcsec=None,
+    log_scale=False,
+    figsize=None,
+    dpi=150,
+    title=None,
+):
+    """Create a gallery figure showing 1D radial PSF profiles.
+
+    Produces a single figure with all PSF radial profiles overlaid for
+    direct comparison. Each profile is azimuthally averaged. PSF data
+    are expected to already be peak-normalized (as produced by tclean).
+    The default x-axis range is 3x the largest beam major axis to
+    focus on inner PSF structure.
+
+    Parameters
+    ----------
+    results : list of dict
+        Results from TestImagingHandler.get_results().
+    imaging_dir : str, optional
+        Base directory containing the test images. If None, uses the
+        current working directory.
+    output_file : str, optional
+        Output filename for the figure. Set to None to skip saving.
+    target : str, optional
+        Filter results to this target.
+    config : str, optional
+        Filter results to this config.
+    product : str, optional
+        Filter results to this product.
+    max_radius_arcsec : float, optional
+        Maximum radius for the profile. If None, defaults to 3x the
+        largest beam major axis in the result set.
+    bin_width_arcsec : float, optional
+        Radial bin width in arcseconds. Enforced to be at least one pixel
+        wide. If None, defaults to one pixel.
+    log_scale : bool
+        If True, use a log scale on the y-axis.
+    figsize : tuple, optional
+        Figure size (width, height) in inches.
+    dpi : int
+        Figure resolution.
+    title : str, optional
+        Figure title. If None, auto-generated.
+
+    Returns
+    -------
+    fig : matplotlib.figure.Figure
+        The figure object.
+    """
+    if not HAS_MATPLOTLIB:
+        logger.error("matplotlib is required for plotting")
+        return None
+
+    filtered = _filter_results(results, target=target, config=config, product=product)
+    if len(filtered) == 0:
+        logger.warning("No results match the filter criteria")
+        return None
+
+    if imaging_dir is None:
+        imaging_dir = '.'
+
+    # Determine default radius from beam sizes (3x largest beam)
+    if max_radius_arcsec is None:
+        max_beam = _get_max_beam_arcsec(filtered)
+        if max_beam is not None:
+            max_radius_arcsec = 3.0 * max_beam
+            logger.info(f"Auto max_radius_arcsec = {max_radius_arcsec:.2f} "
+                        f"(3 x {max_beam:.2f})")
+
+    if figsize is None:
+        figsize = (10, 7)
+
+    fig, ax = plt.subplots(1, 1, figsize=figsize)
+
+    profiles_plotted = 0
+    for result in filtered:
+        # Use cached radial profile when available to avoid re-reading image
+        if '_psf_radii' in result and '_psf_profile' in result:
+            radius = np.asarray(result['_psf_radii'])
+            profile = np.asarray(result['_psf_profile'])
+            # Optionally truncate to the requested x-axis range
+            if max_radius_arcsec is not None and radius[-1] > max_radius_arcsec:
+                mask = radius <= max_radius_arcsec
+                radius = radius[mask]
+                profile = profile[mask]
+        else:
+            image_root = _build_image_root(result)
+            if image_root is None:
+                continue
+            psf_file = os.path.join(imaging_dir, image_root + '.psf')
+            data_2d, pix_scale = _read_image_data(psf_file)
+            if data_2d is None:
+                logger.warning(f"Could not read PSF: {psf_file}")
+                continue
+            radius, profile = _compute_radial_profile(
+                data_2d, pix_scale,
+                max_radius_arcsec=max_radius_arcsec,
+                bin_width_arcsec=bin_width_arcsec,
+            )
+            del data_2d
+
+        label = _make_label(result)
+        line, = ax.plot(radius, profile, label=label, linewidth=1.5)
+
+        # Overlay the Gaussian fit profile using the beam parameters.
+        # The azimuthal average of a 2D elliptical Gaussian with
+        # FWHM (bmaj, bmin) is a 1D Gaussian with sigma equal to the
+        # geometric mean: sigma_eff = sqrt(sigma_maj * sigma_min).
+        bmaj = result.get('bmaj_arcsec')
+        bmin = result.get('bmin_arcsec')
+        if bmaj is not None and bmin is not None:
+            fwhm_to_sigma = 1.0 / (2.0 * np.sqrt(2.0 * np.log(2.0)))
+            sigma_eff = np.sqrt(bmaj * bmin) * fwhm_to_sigma
+            gauss_profile = np.exp(-radius**2 / (2.0 * sigma_eff**2))
+            ax.plot(radius, gauss_profile, color=line.get_color(),
+                    linewidth=1.0, linestyle='--', alpha=0.7)
+
+        profiles_plotted += 1
+
+    if profiles_plotted == 0:
+        logger.warning("No PSF profiles could be plotted")
+        plt.close(fig)
+        return None
+
+    ax.set_xlabel('Radius (arcsec)')
+    ax.set_ylabel('PSF amplitude')
+    ax.axhline(0, color='gray', linewidth=0.5, linestyle='--')
+    ax.legend(fontsize='small', loc='upper right')
+    if max_radius_arcsec is not None:
+        ax.set_xlim(0, max_radius_arcsec)
+    else:
+        ax.set_xlim(left=0)
+
+    if log_scale:
+        ax.set_yscale('symlog', linthresh=0.01)
+        ax.set_ylabel('PSF amplitude (symlog)')
+
+    if title is None:
+        parts = []
+        if target or (len(set(r['target'] for r in filtered)) == 1):
+            parts.append(filtered[0]['target'])
+        if config or (len(set(r['config'] for r in filtered)) == 1):
+            parts.append(filtered[0]['config'])
+        if product or (len(set(r['product'] for r in filtered)) == 1):
+            parts.append(filtered[0]['product'])
+        title = 'PSF Radial Profiles'
+        if parts:
+            title += ' - ' + ' / '.join(parts)
+    ax.set_title(title)
+
+    fig.tight_layout()
+
+    if output_file is not None:
+        fig.savefig(output_file, dpi=dpi, bbox_inches='tight')
+        logger.info(f"Saved PSF radial profile gallery to {output_file}")
+
+    return fig
+
+
+def make_psf_image_gallery(
+    results,
+    imaging_dir=None,
+    output_file=None,
+    target=None,
+    config=None,
+    product=None,
+    zoom_radius_arcsec=None,
+    vmin=-0.1,
+    vmax=1.0,
+    cmap='RdBu_r',
+    show_beam_ellipse=True,
+    max_panels_per_page=9,
+    figsize=None,
+    dpi=150,
+    title=None,
+):
+    """Create a gallery of 2D PSF images as a grid of panels.
+
+    Each panel shows the central region of a PSF image with a
+    consistent color scale. PSF data are expected to already be
+    peak-normalized (as produced by tclean). The default zoom level
+    is 3x the largest beam major axis to focus on inner PSF structure,
+    with all panels sharing the same angular scale.
+
+    If more than ``max_panels_per_page`` results are provided, the
+    gallery is split across multiple enumerated figures/files.
+
+    Parameters
+    ----------
+    results : list of dict
+        Results from TestImagingHandler.get_results().
+    imaging_dir : str, optional
+        Base directory containing the test images. If None, uses the
+        current working directory.
+    output_file : str, optional
+        Output filename for the figure. Set to None to skip saving.
+        When multiple pages are produced, a page number is inserted
+        before the extension (e.g. ``gallery_1.png``, ``gallery_2.png``).
+    target : str, optional
+        Filter results to this target.
+    config : str, optional
+        Filter results to this config.
+    product : str, optional
+        Filter results to this product.
+    zoom_radius_arcsec : float, optional
+        Half-width of the zoomed region in arcseconds. If None,
+        defaults to 3x the largest beam major axis in the result set.
+    vmin : float
+        Minimum color scale value (PSFs are normalized to peak=1).
+    vmax : float
+        Maximum color scale value.
+    cmap : str
+        Matplotlib colormap name.
+    show_beam_ellipse : bool
+        If True, draw the restoring beam ellipse in the lower-left corner.
+    max_panels_per_page : int
+        Maximum number of panels per figure page (default 9, i.e. 3x3).
+    figsize : tuple, optional
+        Figure size. If None, auto-computed from number of panels.
+    dpi : int
+        Figure resolution.
+    title : str, optional
+        Figure supertitle. If None, auto-generated.
+
+    Returns
+    -------
+    list of matplotlib.figure.Figure
+        List of figure objects (one per page).
+    """
+    if not HAS_MATPLOTLIB:
+        logger.error("matplotlib is required for plotting")
+        return []
+
+    filtered = _filter_results(results, target=target, config=config, product=product)
+    if len(filtered) == 0:
+        logger.warning("No results match the filter criteria")
+        return []
+
+    if imaging_dir is None:
+        imaging_dir = '.'
+
+    # Determine default zoom from beam sizes (3x largest beam)
+    if zoom_radius_arcsec is None:
+        max_beam = _get_max_beam_arcsec(filtered)
+        if max_beam is not None:
+            zoom_radius_arcsec = 3.0 * max_beam
+            logger.info(f"Auto zoom_radius_arcsec = {zoom_radius_arcsec:.2f} "
+                        f"(3 x {max_beam:.2f})")
+
+    # Auto-generate base title
+    if title is None:
+        parts = []
+        if target or (len(set(r['target'] for r in filtered)) == 1):
+            parts.append(filtered[0]['target'])
+        if config or (len(set(r['config'] for r in filtered)) == 1):
+            parts.append(filtered[0]['config'])
+        if product or (len(set(r['product'] for r in filtered)) == 1):
+            parts.append(filtered[0]['product'])
+        title = 'PSF Image Gallery'
+        if parts:
+            title += ' - ' + ' / '.join(parts)
+
+    # Split into pages
+    n_pages = math.ceil(len(filtered) / max_panels_per_page)
+    figs = []
+
+    for page_idx in range(n_pages):
+        page_results = filtered[page_idx * max_panels_per_page:
+                                (page_idx + 1) * max_panels_per_page]
+        n = len(page_results)
+        nrows, ncols = _get_grid_layout(n)
+
+        if figsize is None:
+            this_figsize = (4.5 * ncols, 4.0 * nrows + 0.6)
+        else:
+            this_figsize = figsize
+
+        fig, axes = plt.subplots(nrows, ncols, figsize=this_figsize, squeeze=False)
+
+        panels_plotted = 0
+        for idx, result in enumerate(page_results):
+            row = idx // ncols
+            col = idx % ncols
+            ax = axes[row][col]
+
+            image_root = _build_image_root(result)
+            if image_root is None:
+                ax.set_visible(False)
+                continue
+            psf_file = os.path.join(imaging_dir, image_root + '.psf')
+
+            data_2d, pix_scale = _read_image_data(psf_file)
+            if data_2d is None:
+                logger.warning(f"Could not read PSF: {psf_file}")
+                ax.text(0.5, 0.5, 'No data', transform=ax.transAxes,
+                        ha='center', va='center')
+                ax.set_title(result.get('test_name', '?'), fontsize=9)
+                continue
+
+            ny, nx = data_2d.shape
+
+            # Build coordinate arrays in arcsec offset from center
+            cy, cx = ny // 2, nx // 2
+            extent_x = (np.arange(nx) - cx) * pix_scale
+            extent_y = (np.arange(ny) - cy) * pix_scale
+            extent = [extent_x[0], extent_x[-1], extent_y[0], extent_y[-1]]
+
+            ax.imshow(data_2d, origin='lower', extent=extent,
+                      vmin=vmin, vmax=vmax, cmap=cmap, aspect='equal')
+
+            # Zoom (common scale for all panels)
+            if zoom_radius_arcsec is not None:
+                ax.set_xlim(-zoom_radius_arcsec, zoom_radius_arcsec)
+                ax.set_ylim(-zoom_radius_arcsec, zoom_radius_arcsec)
+
+            # Crop data to zoom region before contouring (contour processes
+            # the full array unlike imshow, so this avoids huge memory/CPU
+            # cost on large images).
+            zoom_r = zoom_radius_arcsec if zoom_radius_arcsec is not None else None
+            if zoom_r is not None:
+                margin_pix = int(zoom_r / pix_scale) + 2
+                x0 = max(cx - margin_pix, 0)
+                x1 = min(cx + margin_pix + 1, nx)
+                y0 = max(cy - margin_pix, 0)
+                y1 = min(cy + margin_pix + 1, ny)
+            else:
+                x0, x1, y0, y1 = 0, nx, 0, ny
+            crop = np.array(data_2d[y0:y1, x0:x1])
+            del data_2d
+            x_crop = (np.arange(x0, x1) - cx) * pix_scale
+            y_crop = (np.arange(y0, y1) - cy) * pix_scale
+
+            # Contour at the 0.5 level (half-power)
+            ax.contour(x_crop, y_crop, crop, levels=[0.5],
+                       colors='black', linewidths=1.0)
+
+            # Gaussian fit ellipse at center (FWHM from beam parameters)
+            bmaj = result.get('bmaj_arcsec')
+            bmin = result.get('bmin_arcsec')
+            bpa = result.get('bpa_deg', 0)
+            if bmaj is not None and bmin is not None:
+                gauss_ellipse = Ellipse(
+                    (0, 0), width=bmin, height=bmaj, angle=-bpa + 90,
+                    edgecolor='lime', facecolor='none',
+                    linewidth=1.2, linestyle='--')
+                ax.add_patch(gauss_ellipse)
+
+            # Beam ellipse
+            if show_beam_ellipse:
+                bmaj = result.get('bmaj_arcsec')
+                bmin = result.get('bmin_arcsec')
+                bpa = result.get('bpa_deg', 0)
+                if bmaj is not None and bmin is not None:
+                    xlim = ax.get_xlim()
+                    ylim = ax.get_ylim()
+                    # Position in lower-left corner
+                    ex = xlim[0] + 0.15 * (xlim[1] - xlim[0])
+                    ey = ylim[0] + 0.15 * (ylim[1] - ylim[0])
+                    ellipse = Ellipse(
+                        (ex, ey), width=bmin, height=bmaj, angle=-bpa + 90,
+                        edgecolor='black', facecolor='gold', alpha=0.7,
+                        linewidth=1.0)
+                    ax.add_patch(ellipse)
+
+            # Panel label
+            label = result.get('test_name', '?')
+            bmaj = result.get('bmaj_arcsec')
+            bmin = result.get('bmin_arcsec')
+            if bmaj is not None and bmin is not None:
+                label += f'\n{bmaj:.2f}x{bmin:.2f}"'
+            ax.set_title(label, fontsize=9)
+            ax.set_xlabel('Offset (arcsec)', fontsize=8)
+            ax.set_ylabel('Offset (arcsec)', fontsize=8)
+            ax.tick_params(labelsize=7)
+            panels_plotted += 1
+
+        # Hide unused panels
+        for idx in range(n, nrows * ncols):
+            row = idx // ncols
+            col = idx % ncols
+            axes[row][col].set_visible(False)
+
+        if panels_plotted == 0:
+            logger.warning("No PSF images could be plotted on page "
+                           f"{page_idx + 1}")
+            plt.close(fig)
+            continue
+
+        # Supertitle
+        page_title = title
+        if n_pages > 1:
+            page_title += f' ({page_idx + 1}/{n_pages})'
+        fig.suptitle(page_title, fontsize=12, y=1.01)
+
+        fig.tight_layout()
+
+        page_file = _paginated_output_file(output_file, page_idx, n_pages)
+        if page_file is not None:
+            fig.savefig(page_file, dpi=dpi, bbox_inches='tight')
+            logger.info(f"Saved PSF image gallery to {page_file}")
+
+        figs.append(fig)
+
+    return figs
+
+
+def make_image_gallery(
+    results,
+    imaging_dir=None,
+    output_file=None,
+    target=None,
+    config=None,
+    product=None,
+    zoom_radius_arcsec=None,
+    vmin=None,
+    vmax=None,
+    cmap='inferno',
+    show_beam_ellipse=True,
+    symmetric_color=False,
+    sigma_clip=3.0,
+    max_panels_per_page=9,
+    figsize=None,
+    dpi=150,
+    title=None,
+):
+    """Create a gallery of 2D dirty images as a grid of panels.
+
+    Each panel shows a dirty image from a different test parameter
+    combination. Color scales are determined per-panel or can be
+    set globally.
+
+    If more than ``max_panels_per_page`` results are provided, the
+    gallery is split across multiple enumerated figures/files.
+
+    Parameters
+    ----------
+    results : list of dict
+        Results from TestImagingHandler.get_results().
+    imaging_dir : str, optional
+        Base directory containing the test images. If None, uses the
+        current working directory.
+    output_file : str, optional
+        Output filename for the figure. Set to None to skip saving.
+        When multiple pages are produced, a page number is inserted
+        before the extension (e.g. ``gallery_1.png``, ``gallery_2.png``).
+    target : str, optional
+        Filter results to this target.
+    config : str, optional
+        Filter results to this config.
+    product : str, optional
+        Filter results to this product.
+    zoom_radius_arcsec : float, optional
+        Half-width of the displayed region in arcseconds. If None,
+        shows the full image.
+    vmin : float, optional
+        Minimum color scale value. If None, auto-determined per panel.
+    vmax : float, optional
+        Maximum color scale value. If None, auto-determined per panel.
+    cmap : str
+        Matplotlib colormap name.
+    show_beam_ellipse : bool
+        If True, draw the restoring beam ellipse on each panel.
+    symmetric_color : bool
+        If True and vmin/vmax are not set, use a symmetric color range
+        centered on zero and switch to a diverging colormap.
+    sigma_clip : float
+        When auto-determining color range, clip at this many sigma
+        above/below the median.
+    max_panels_per_page : int
+        Maximum number of panels per figure page (default 9, i.e. 3x3).
+    figsize : tuple, optional
+        Figure size. If None, auto-computed from number of panels.
+    dpi : int
+        Figure resolution.
+    title : str, optional
+        Figure supertitle. If None, auto-generated.
+
+    Returns
+    -------
+    list of matplotlib.figure.Figure
+        List of figure objects (one per page).
+    """
+    if not HAS_MATPLOTLIB:
+        logger.error("matplotlib is required for plotting")
+        return []
+
+    filtered = _filter_results(results, target=target, config=config, product=product)
+    if len(filtered) == 0:
+        logger.warning("No results match the filter criteria")
+        return []
+
+    if imaging_dir is None:
+        imaging_dir = '.'
+
+    # Auto-generate base title
+    if title is None:
+        parts = []
+        if target or (len(set(r['target'] for r in filtered)) == 1):
+            parts.append(filtered[0]['target'])
+        if config or (len(set(r['config'] for r in filtered)) == 1):
+            parts.append(filtered[0]['config'])
+        if product or (len(set(r['product'] for r in filtered)) == 1):
+            parts.append(filtered[0]['product'])
+        title = 'Dirty Image Gallery'
+        if parts:
+            title += ' - ' + ' / '.join(parts)
+
+    # Split into pages
+    n_pages = math.ceil(len(filtered) / max_panels_per_page)
+    figs = []
+
+    for page_idx in range(n_pages):
+        page_results = filtered[page_idx * max_panels_per_page:
+                                (page_idx + 1) * max_panels_per_page]
+        n = len(page_results)
+        nrows, ncols = _get_grid_layout(n)
+
+        if figsize is None:
+            this_figsize = (4.5 * ncols, 4.0 * nrows + 0.6)
+        else:
+            this_figsize = figsize
+
+        fig, axes = plt.subplots(nrows, ncols, figsize=this_figsize,
+                                 squeeze=False)
+
+        panels_plotted = 0
+        for idx, result in enumerate(page_results):
+            row = idx // ncols
+            col = idx % ncols
+            ax = axes[row][col]
+
+            image_root = _build_image_root(result)
+            if image_root is None:
+                ax.set_visible(False)
+                continue
+            image_file = os.path.join(imaging_dir, image_root + '.image')
+
+            data_2d, pix_scale = _read_image_data(image_file)
+            if data_2d is None:
+                logger.warning(f"Could not read image: {image_file}")
+                ax.text(0.5, 0.5, 'No data', transform=ax.transAxes,
+                        ha='center', va='center')
+                ax.set_title(result.get('test_name', '?'), fontsize=9)
+                continue
+
+            ny, nx = data_2d.shape
+
+            # Build coordinate arrays in arcsec offset from center
+            cy, cx = ny // 2, nx // 2
+            extent_x = (np.arange(nx) - cx) * pix_scale
+            extent_y = (np.arange(ny) - cy) * pix_scale
+            extent = [extent_x[0], extent_x[-1], extent_y[0], extent_y[-1]]
+
+            # Determine color scale
+            this_vmin = vmin
+            this_vmax = vmax
+            this_cmap = cmap
+            if this_vmin is None or this_vmax is None:
+                finite_data = data_2d[np.isfinite(data_2d)]
+                if len(finite_data) > 0:
+                    med = np.median(finite_data)
+                    std = np.std(finite_data)
+                    if symmetric_color:
+                        absmax = max(abs(med - sigma_clip * std),
+                                     abs(med + sigma_clip * std))
+                        this_vmin = -absmax if this_vmin is None else this_vmin
+                        this_vmax = absmax if this_vmax is None else this_vmax
+                        this_cmap = 'RdBu_r'
+                    else:
+                        this_vmin = (med - sigma_clip * std) if this_vmin is None else this_vmin
+                        this_vmax = (med + sigma_clip * std) if this_vmax is None else this_vmax
+
+            im = ax.imshow(data_2d, origin='lower', extent=extent,
+                           vmin=this_vmin, vmax=this_vmax, cmap=this_cmap,
+                           aspect='equal')
+            del data_2d
+
+            # Zoom
+            if zoom_radius_arcsec is not None:
+                ax.set_xlim(-zoom_radius_arcsec, zoom_radius_arcsec)
+                ax.set_ylim(-zoom_radius_arcsec, zoom_radius_arcsec)
+
+            # Colorbar
+            cbar = fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+            cbar.ax.tick_params(labelsize=7)
+
+            # Beam ellipse
+            if show_beam_ellipse:
+                bmaj = result.get('bmaj_arcsec')
+                bmin = result.get('bmin_arcsec')
+                bpa = result.get('bpa_deg', 0)
+                if bmaj is not None and bmin is not None:
+                    xlim = ax.get_xlim()
+                    ylim = ax.get_ylim()
+                    ex = xlim[0] + 0.10 * (xlim[1] - xlim[0])
+                    ey = ylim[0] + 0.10 * (ylim[1] - ylim[0])
+                    ellipse = Ellipse(
+                        (ex, ey), width=bmin, height=bmaj, angle=-bpa,
+                        edgecolor='white', facecolor='none',
+                        linewidth=1.5)
+                    ax.add_patch(ellipse)
+
+            # Panel label
+            label = result.get('test_name', '?')
+            bmaj = result.get('bmaj_arcsec')
+            bmin = result.get('bmin_arcsec')
+            rms = result.get('rms')
+            sublabel_parts = []
+            if bmaj is not None and bmin is not None:
+                sublabel_parts.append(f'{bmaj:.2f}x{bmin:.2f}"')
+            if rms is not None:
+                sublabel_parts.append(f'rms={rms:.2e}')
+            if sublabel_parts:
+                label += '\n' + ', '.join(sublabel_parts)
+            ax.set_title(label, fontsize=9)
+            ax.set_xlabel('Offset (arcsec)', fontsize=8)
+            ax.set_ylabel('Offset (arcsec)', fontsize=8)
+            ax.tick_params(labelsize=7)
+            panels_plotted += 1
+
+        # Hide unused panels
+        for idx in range(n, nrows * ncols):
+            row = idx // ncols
+            col = idx % ncols
+            axes[row][col].set_visible(False)
+
+        if panels_plotted == 0:
+            logger.warning(f"No images could be plotted on page "
+                           f"{page_idx + 1}")
+            plt.close(fig)
+            continue
+
+        # Supertitle
+        page_title = title
+        if n_pages > 1:
+            page_title += f' ({page_idx + 1}/{n_pages})'
+        fig.suptitle(page_title, fontsize=12, y=1.01)
+
+        fig.tight_layout()
+
+        page_file = _paginated_output_file(output_file, page_idx, n_pages)
+        if page_file is not None:
+            fig.savefig(page_file, dpi=dpi, bbox_inches='tight')
+            logger.info(f"Saved image gallery to {page_file}")
+
+        figs.append(fig)
+
+    return figs
+
+
+# ---------------------------------------------------------------
+# Metrics-vs-robust gallery
+# ---------------------------------------------------------------
+
+
+# Default metrics shown in the gallery.
+# Each entry is either:
+#   (result_key, y_label)                       — single line per series
+#   ((key1, key2), y_label, (name1, name2))     — paired lines (solid + dashed)
+_DEFAULT_METRIC_DEFS = [
+    (('bmaj_arcsec', 'bmin_arcsec'), 'Beam size (arcsec)', ('major', 'minor')),
+    ('bpa_deg',      'Beam PA (deg)'),
+    ('rms',          'RMS'),
+    ('kappa',        'Kappa'),
+    ('epsilon',          'epsilon'),
+    ('skirt_level',  'Skirt level'),
+]
+
+
+def _parse_metric_def(metric_def):
+    """Normalise a metric definition into (keys, ylabel, key_labels).
+
+    Parameters
+    ----------
+    metric_def : tuple
+        Either ``(key, ylabel)`` or ``((key1, key2, ...), ylabel, (name1, name2, ...))``.
+
+    Returns
+    -------
+    keys : tuple of str
+    ylabel : str
+    key_labels : tuple of str or None
+    """
+    if len(metric_def) == 3:
+        keys, ylabel, key_labels = metric_def
+        if isinstance(keys, str):
+            keys = (keys,)
+            key_labels = (key_labels,)
+        return tuple(keys), ylabel, tuple(key_labels)
+    else:
+        key, ylabel = metric_def
+        if isinstance(key, str):
+            return (key,), ylabel, None
+        return tuple(key), ylabel, None
+
+
+def make_metrics_vs_robust_gallery(
+    results,
+    output_file=None,
+    target=None,
+    config=None,
+    product=None,
+    metrics=None,
+    figsize=None,
+    dpi=150,
+    title=None,
+):
+    """Create a multi-panel figure of imaging metrics vs. robust parameter.
+
+    Each panel shows one metric on the y-axis and the robust parameter
+    on the x-axis.  Results with different weightings (e.g. natural,
+    uniform) that lack a robust value are plotted as isolated markers
+    at the edges.  Different taper values are shown as separate
+    series.
+
+    Panels may show paired quantities (e.g. beam major and minor axis)
+    on the same y-axis using solid and dashed lines.
+
+    Parameters
+    ----------
+    results : list of dict
+        Results from ``TestImagingHandler.get_results()``.
+    output_file : str, optional
+        Output filename.  Set to None to skip saving.
+    target : str, optional
+        Filter results to this target.
+    config : str, optional
+        Filter results to this config.
+    product : str, optional
+        Filter results to this product.
+    metrics : list of tuple, optional
+        Metric definitions for each panel.  Each entry is either
+        ``(result_key, y_label)`` for a single quantity, or
+        ``((key1, key2), y_label, (name1, name2))`` to show two
+        quantities on the same panel with solid/dashed lines.
+        Defaults to beam size (major + minor), beam PA, RMS, kappa,
+        epsilon, and skirt level.
+    figsize : tuple, optional
+        Figure size ``(width, height)`` in inches.
+    dpi : int
+        Figure resolution.
+    title : str, optional
+        Figure super-title.
+
+    Returns
+    -------
+    matplotlib.figure.Figure or None
+    """
+    if not HAS_MATPLOTLIB:
+        logger.error("matplotlib is required for plotting")
+        return None
+
+    filtered = _filter_results(results, target=target, config=config,
+                               product=product)
+    if len(filtered) == 0:
+        logger.warning("No results match the filter criteria")
+        return None
+
+    if metrics is None:
+        metrics = list(_DEFAULT_METRIC_DEFS)
+
+    parsed = [_parse_metric_def(m) for m in metrics]
+    n_panels = len(parsed)
+    if n_panels == 0:
+        return None
+
+    if figsize is None:
+        figsize = (8, 3.0 * n_panels)
+
+    fig, axes = plt.subplots(n_panels, 1, figsize=figsize, sharex=True,
+                             squeeze=False)
+    axes = axes[:, 0]
+
+    # Group results by taper value for separate series
+    taper_set = sorted(set(r.get('taper_arcsec', 0.0) or 0.0
+                           for r in filtered))
+
+    markers = ['o', 's', '^', 'D', 'v', 'P', '*', 'X']
+    linestyles = ['-', '--', ':', '-.']
+
+    for panel_idx, (keys, ylabel, key_labels) in enumerate(parsed):
+        ax = axes[panel_idx]
+
+        for tap_idx, taper in enumerate(taper_set):
+            tap_results = [r for r in filtered
+                           if (r.get('taper_arcsec', 0.0) or 0.0) == taper]
+
+            marker = markers[tap_idx % len(markers)]
+            tap_label = f'taper {taper:.1f}"' if taper > 0 else 'no taper'
+
+            for k_idx, key in enumerate(keys):
+                ls = linestyles[k_idx % len(linestyles)]
+
+                # Build legend label
+                if key_labels is not None:
+                    label = f'{tap_label}, {key_labels[k_idx]}'
+                else:
+                    label = tap_label
+
+                # Separate Briggs (has robust) from non-Briggs
+                briggs = [r for r in tap_results
+                          if r.get('robust') is not None
+                          and r.get(key) is not None]
+                other = [r for r in tap_results
+                         if r.get('robust') is None
+                         and r.get(key) is not None]
+
+                if briggs:
+                    briggs_sorted = sorted(briggs, key=lambda r: r['robust'])
+                    x = [r['robust'] for r in briggs_sorted]
+                    y = [r[key] for r in briggs_sorted]
+                    ax.plot(x, y, marker=marker, label=label,
+                            linewidth=1.2, markersize=6, linestyle=ls)
+
+                for r in other:
+                    weighting = r.get('weighting', '?')
+                    yval = r[key]
+                    if weighting == 'natural':
+                        xpos = 2.5
+                    elif weighting == 'uniform':
+                        xpos = -2.5
+                    else:
+                        xpos = 3.0
+                    ax.plot(xpos, yval, marker=marker, markersize=8,
+                            linestyle='none', color='gray', alpha=0.7)
+                    ann = weighting
+                    if key_labels is not None:
+                        ann += f' ({key_labels[k_idx]})'
+                    ax.annotate(ann, (xpos, yval), fontsize=7,
+                                textcoords='offset points', xytext=(5, 3))
+
+        ax.set_ylabel(ylabel, fontsize=10)
+        ax.grid(True, alpha=0.3)
+        if panel_idx == 0:
+            ax.legend(fontsize='small', loc='best')
+
+    axes[-1].set_xlabel('Robust parameter', fontsize=10)
+
+    if title is None:
+        parts = []
+        if target or (len(set(r['target'] for r in filtered)) == 1):
+            parts.append(filtered[0]['target'])
+        if config or (len(set(r.get('config', '') for r in filtered)) == 1):
+            parts.append(filtered[0].get('config', ''))
+        title = ' / '.join(parts) if parts else 'Metrics vs. Robust'
+    fig.suptitle(title, fontsize=12, y=1.01)
+
+    fig.tight_layout()
+
+    if output_file is not None:
+        fig.savefig(output_file, dpi=dpi, bbox_inches='tight')
+        logger.info(f"Saved metrics-vs-robust gallery to {output_file}")
+
+    return fig
+
+
+# ---------------------------------------------------------------
+# Metrics-vs-beam gallery
+# ---------------------------------------------------------------
+
+
+_DEFAULT_BEAM_METRIC_DEFS = [
+    ('bpa_deg',      'Beam PA (deg)'),
+    ('rms',          'RMS'),
+    ('kappa',        'Kappa'),
+    ('epsilon',          'epsilon'),
+    ('skirt_level',  'Skirt level'),
+]
+
+
+def _series_label(weighting, taper):
+    """Build a concise legend label from weighting and taper."""
+    parts = [weighting]
+    if taper and taper > 0:
+        parts.append(f'taper {taper:.1f}"')
+    return ', '.join(parts)
+
+
+def make_metrics_vs_beam_gallery(
+    results,
+    output_file=None,
+    target=None,
+    config=None,
+    product=None,
+    metrics=None,
+    beam_key='bmaj_arcsec',
+    beam_label='Beam major axis (arcsec)',
+    figsize=None,
+    dpi=150,
+    title=None,
+):
+    """Create a multi-panel figure of imaging metrics vs. beam size.
+
+    Each panel shows one metric on the y-axis and the beam size on
+    the x-axis.  All results — regardless of weighting scheme (Briggs,
+    natural, uniform) or UV taper — are plotted together, with each
+    weighting+taper combination as a distinct series.  Points are
+    labelled with the robust value or weighting name.
+
+    Panels may show paired quantities using solid and dashed lines
+    (see ``metrics`` parameter).
+
+    Parameters
+    ----------
+    results : list of dict
+        Results from ``TestImagingHandler.get_results()``.
+    output_file : str, optional
+        Output filename.  Set to None to skip saving.
+    target : str, optional
+        Filter results to this target.
+    config : str, optional
+        Filter results to this config.
+    product : str, optional
+        Filter results to this product.
+    metrics : list of tuple, optional
+        Metric definitions for each panel.  Each entry is either
+        ``(result_key, y_label)`` for a single quantity, or
+        ``((key1, key2), y_label, (name1, name2))`` to show two
+        quantities on the same panel.
+        Defaults to beam PA, RMS, kappa, epsilon, and skirt level.
+    beam_key : str
+        Result dictionary key for the x-axis beam size.
+    beam_label : str
+        X-axis label.
+    figsize : tuple, optional
+        Figure size ``(width, height)`` in inches.
+    dpi : int
+        Figure resolution.
+    title : str, optional
+        Figure super-title.
+
+    Returns
+    -------
+    matplotlib.figure.Figure or None
+    """
+    if not HAS_MATPLOTLIB:
+        logger.error("matplotlib is required for plotting")
+        return None
+
+    filtered = _filter_results(results, target=target, config=config,
+                               product=product)
+    filtered = [r for r in filtered if r.get(beam_key) is not None]
+    if len(filtered) == 0:
+        logger.warning("No results with beam measurements match the filter")
+        return None
+
+    if metrics is None:
+        metrics = list(_DEFAULT_BEAM_METRIC_DEFS)
+
+    parsed = [_parse_metric_def(m) for m in metrics]
+    n_panels = len(parsed)
+    if n_panels == 0:
+        return None
+
+    if figsize is None:
+        figsize = (8, 3.0 * n_panels)
+
+    fig, axes = plt.subplots(n_panels, 1, figsize=figsize, sharex=True,
+                             squeeze=False)
+    axes = axes[:, 0]
+
+    # Group by (weighting, taper) for distinct series
+    series_keys = []
+    seen = set()
+    for r in filtered:
+        w = r.get('weighting', 'unknown')
+        t = r.get('taper_arcsec', 0.0) or 0.0
+        k = (w, t)
+        if k not in seen:
+            seen.add(k)
+            series_keys.append(k)
+
+    markers_list = ['o', 's', '^', 'D', 'v', 'P', '*', 'X']
+    colors = plt.rcParams['axes.prop_cycle'].by_key()['color']
+    linestyles = ['-', '--', ':', '-.']
+
+    for panel_idx, (keys, ylabel, key_labels) in enumerate(parsed):
+        ax = axes[panel_idx]
+
+        for s_idx, (weighting, taper) in enumerate(series_keys):
+            marker = markers_list[s_idx % len(markers_list)]
+            color = colors[s_idx % len(colors)]
+            base_label = _series_label(weighting, taper)
+
+            for k_idx, key in enumerate(keys):
+                ls = linestyles[k_idx % len(linestyles)]
+                if key_labels is not None:
+                    label = f'{base_label}, {key_labels[k_idx]}'
+                else:
+                    label = base_label
+
+                s_results = [r for r in filtered
+                             if r.get('weighting', 'unknown') == weighting
+                             and (r.get('taper_arcsec', 0.0) or 0.0) == taper
+                             and r.get(key) is not None]
+                if not s_results:
+                    continue
+
+                s_results = sorted(s_results, key=lambda r: r[beam_key])
+                x = [r[beam_key] for r in s_results]
+                y = [r[key] for r in s_results]
+
+                ax.plot(x, y, marker=marker, color=color, label=label,
+                        linewidth=1.2, markersize=6, linestyle=ls)
+
+                # Annotate only the primary key to avoid clutter
+                if k_idx == 0:
+                    for r, xi, yi in zip(s_results, x, y):
+                        rob = r.get('robust')
+                        ann = f'r={rob}' if rob is not None else weighting
+                        ax.annotate(ann, (xi, yi), fontsize=6,
+                                    textcoords='offset points', xytext=(4, 4),
+                                    color=color, alpha=0.8)
+
+        ax.set_ylabel(ylabel, fontsize=10)
+        ax.grid(True, alpha=0.3)
+        if panel_idx == 0:
+            ax.legend(fontsize='small', loc='best')
+
+    axes[-1].set_xlabel(beam_label, fontsize=10)
+
+    if title is None:
+        parts = []
+        if target or (len(set(r['target'] for r in filtered)) == 1):
+            parts.append(filtered[0]['target'])
+        if config or (len(set(r.get('config', '') for r in filtered)) == 1):
+            parts.append(filtered[0].get('config', ''))
+        title = ' / '.join(parts) if parts else 'Metrics vs. Beam Size'
+    fig.suptitle(title, fontsize=12, y=1.01)
+
+    fig.tight_layout()
+
+    if output_file is not None:
+        fig.savefig(output_file, dpi=dpi, bbox_inches='tight')
+        logger.info(f"Saved metrics-vs-beam gallery to {output_file}")
+
+    return fig
+
+
+# ---------------------------------------------------------------
+# HTML summary report
+# ---------------------------------------------------------------
+
+_METRIC_DESCRIPTIONS = {
+    'kappa': (
+        'Kappa',
+        'The sum of the difference between the azimuthally averaged '
+        'radial PSF profile and the best-fit Gaussian (from the beam), '
+        'evaluated within the FWHM and normalised by the Gaussian area '
+        'inside the FWHM. Kappa measures how close the PSF within the '
+        'FWHM is to a Gaussian. Kappa &lt; 0 means the PSF is more peaked '
+        'relative to the Gaussian model. Kappa &gt; 0 means the PSF is '
+        'flatter relative to the Gaussian model. '
+        'See Koch+2018 Eq. 7.'
+    ),
+    'epsilon': (
+        'Epsilon',
+        'Ratio of the summed ideal Gaussian beam to the summed dirty PSF '
+        'within a window around the peak, after masking regions beyond '
+        'the first null. Values close to 1 indicate a well-behaved PSF.'
+        'We use the definition from Czekala+2021.'
+    ),
+    'skirt_level': (
+        'Skirt Level',
+        'The PSF amplitude at 2 sqrt(2 log 2) sigma (i.e., FWHM in radius), '
+        'estimated via spline interpolation of the azimuthally averaged '
+        'radial profile. For clarity, "FWHM" means a radius at the FWHM, '
+        'not the true FWHM converted to a radius. If the PSF is a Gaussian, '
+        'the skirt level should be exp(&minus;4 log(2)) &asymp; 0.0625.'
+    ),
+}
+
+
+def make_html_report(
+    results,
+    plot_files=None,
+    output_file='report.html',
+    target=None,
+    title=None,
+):
+    """Generate a self-contained HTML summary report.
+
+    Produces an HTML file that embeds all diagnostic plots as base64
+    images and includes a metrics summary table with definitions of
+    the key PSF quality metrics.
+
+    Parameters
+    ----------
+    results : list of dict
+        Results from ``TestImagingHandler.get_results()``, typically
+        pre-filtered to a single target.
+    plot_files : dict, optional
+        Dictionary mapping plot names (e.g. ``'psf_profiles'``,
+        ``'psf_gallery'``) to file paths (str) or lists of file
+        paths.  Each image file is embedded in the report.
+    output_file : str, optional
+        Output HTML filename.
+    target : str, optional
+        Target name for the report title.
+    title : str, optional
+        Custom report title.  If None, auto-generated from target.
+
+    Returns
+    -------
+    str or None
+        Path to the written HTML file.
+    """
+
+    if plot_files is None:
+        plot_files = {}
+
+    if title is None:
+        title = f'Test Imaging Report: {target}' if target else 'Test Imaging Report'
+
+    # --- Build the metrics table rows ---
+    table_columns = [
+        ('test_name', 'Test'),
+        ('config', 'Config'),
+        ('weighting', 'Weighting'),
+        ('robust', 'Robust'),
+        ('taper_arcsec', 'Taper (")'),
+        ('cell_arcsec', 'Cell (")'),
+        ('bmaj_arcsec', 'B<sub>maj</sub> (")'),
+        ('bmin_arcsec', 'B<sub>min</sub> (")'),
+        ('bpa_deg', 'BPA (&deg;)'),
+        ('rms', 'RMS'),
+        ('kappa', 'Kappa'),
+        ('epsilon', 'Epsilon'),
+        ('skirt_level', 'Skirt'),
+    ]
+
+    def _fmt(val, key):
+        if val is None:
+            return '&mdash;'
+        if key == 'rms':
+            return f'{val:.2e}'
+        if isinstance(val, float):
+            return f'{val:.4f}'
+        return str(val)
+
+    header_row = ''.join(f'<th>{label}</th>' for _, label in table_columns)
+    data_rows = []
+    for r in results:
+        cells = ''.join(
+            f'<td>{_fmt(r.get(k), k)}</td>' for k, _ in table_columns
+        )
+        data_rows.append(f'<tr>{cells}</tr>')
+
+    # --- Embed plot images ---
+    plot_sections = []
+    plot_display_names = {
+        'psf_profiles': 'PSF Radial Profiles',
+        'psf_gallery': 'PSF Image Gallery',
+        'image_gallery': 'Dirty Image Gallery',
+        'metrics_vs_robust': 'Metrics vs. Robust',
+        'metrics_vs_beam': 'Metrics vs. Beam Size',
+    }
+
+    for plot_key, paths in plot_files.items():
+        if paths is None:
+            continue
+        if isinstance(paths, str):
+            paths = [paths]
+        # Handle dict returns (per-target) by extracting the values
+        if isinstance(paths, dict):
+            all_paths = []
+            for v in paths.values():
+                if isinstance(v, list):
+                    all_paths.extend(v)
+                elif v is not None:
+                    all_paths.append(v)
+            paths = all_paths
+
+        section_title = plot_display_names.get(plot_key, plot_key)
+        img_tags = []
+        for p in paths:
+            if isinstance(p, str) and os.path.isfile(p):
+                with open(p, 'rb') as f:
+                    data = base64.b64encode(f.read()).decode('ascii')
+                img_tags.append(
+                    f'<img src="data:image/png;base64,{data}" '
+                    f'alt="{plot_key}" '
+                    f'style="max-width:100%; margin:10px 0;">'
+                )
+
+        if img_tags:
+            plot_sections.append(
+                f'<h2>{section_title}</h2>\n' + '\n'.join(img_tags)
+            )
+
+    # --- Metric definitions ---
+    metric_defs_html = []
+    for _, (name, description) in _METRIC_DESCRIPTIONS.items():
+        metric_defs_html.append(
+            f'<dt><strong>{name}</strong></dt>\n<dd>{description}</dd>'
+        )
+
+    # --- Assemble HTML ---
+    timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+
+    html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{title}</title>
+<style>
+  body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
+         Roboto, Helvetica, Arial, sans-serif;
+         max-width: 1200px; margin: 0 auto; padding: 20px;
+         color: #333; background: #fafafa; }}
+  h1 {{ border-bottom: 2px solid #2c5f8a; padding-bottom: 8px; color: #2c5f8a; }}
+  h2 {{ color: #2c5f8a; margin-top: 30px; }}
+  table {{ border-collapse: collapse; width: 100%; margin: 15px 0;
+           font-size: 0.9em; }}
+  th, td {{ border: 1px solid #ccc; padding: 6px 10px; text-align: right; }}
+  th {{ background: #2c5f8a; color: #fff; text-align: center; }}
+  tr:nth-child(even) {{ background: #eef3f8; }}
+  tr:hover {{ background: #d6e4f0; }}
+  dl {{ margin: 15px 0; }}
+  dt {{ margin-top: 12px; font-size: 1.0em; }}
+  dd {{ margin-left: 20px; color: #555; line-height: 1.5; }}
+  .timestamp {{ color: #999; font-size: 0.85em; margin-top: 40px;
+                border-top: 1px solid #ddd; padding-top: 8px; }}
+  img {{ border: 1px solid #ddd; border-radius: 4px; }}
+</style>
+</head>
+<body>
+<h1>{title}</h1>
+
+<h2>Summary Table</h2>
+<table>
+<thead><tr>{header_row}</tr></thead>
+<tbody>
+{''.join(data_rows)}
+</tbody>
+</table>
+
+{''.join(plot_sections)}
+
+<h2>Metric Definitions</h2>
+<dl>
+{''.join(metric_defs_html)}
+</dl>
+
+<p class="timestamp">Report generated {timestamp}</p>
+</body>
+</html>"""
+
+    if output_file is not None:
+        with open(output_file, 'w') as f:
+            f.write(html)
+        logger.info(f"Saved HTML report to {output_file}")
+
+    return output_file
+
+
+# ---------------------------------------------------------------
+# PSF metric functions
+# ---------------------------------------------------------------
+
+
+def measure_kappa(radii, psf_radial, bmaj, bmin):
+    """Compute kappa, the normalised PSF deviation from a Gaussian.
+
+    Kappa is the sum of the difference between the azimuthally averaged
+    radial PSF profile and the best-fit Gaussian (from the beam),
+    evaluated within the FWHM and normalised by the Gaussian area
+    inside the FWHM.
+
+    Kappa measures how close the PSF within the FWHM is to a Gaussian.
+    Kappa < 0 means the PSF is more peaked relative to the Gaussian model.
+    Kappa > 0 means the PSF is flatter relative to the Gaussian model.
+
+    See Koch+2018 Equation 7.
+
+    Parameters
+    ----------
+    radii : numpy.ndarray
+        Radial bin centres in arcseconds.
+    psf_radial : numpy.ndarray
+        Azimuthally averaged PSF profile values at each radius.
+    bmaj : float
+        Beam major axis FWHM in arcseconds.
+    bmin : float
+        Beam minor axis FWHM in arcseconds.
+
+    Returns
+    -------
+    float or None
+        The kappa metric value.
+    """
+    radii = np.asarray(radii, dtype=float)
+    psf_radial = np.asarray(psf_radial, dtype=float)
+
+    # Remove NaN bins (empty annuli at large radii)
+    valid = ~np.isnan(psf_radial)
+    radii = radii[valid]
+    psf_radial = psf_radial[valid]
+
+    if len(radii) == 0:
+        return None
+
+    sigma = np.sqrt(bmaj * bmin) / fwhm_factor
+    hwhm = np.sqrt(bmaj * bmin) / 2.0  # half-width at half maximum
+
+    # Gaussian model evaluated at the radial bin centres
+    gauss_profile = np.exp(-radii**2 / (2.0 * sigma**2))
+
+    # Mask to within the half-max radius (FWHM/2)
+    hwhm_mask = radii <= hwhm
+
+    if not np.any(hwhm_mask):
+        return None
+
+    # Normalise by the Gaussian sum within the same region
+    gauss_sum = np.sum(gauss_profile[hwhm_mask])
+    kappa = np.sum(psf_radial[hwhm_mask] - gauss_profile[hwhm_mask]) / gauss_sum
+
+    return float(kappa)
+
+
+def measure_skirt_level(radii, psf_radial, bmaj, bmin):
+    """Estimate the PSF amplitude at 2 sqrt(2 log 2) sigma (i.e., FWHM in radius).
+
+    For clarity, "FWHM" means a radius at the FWHM, not the true FWHM converted
+    to a radius.
+
+    Uses a spline interpolation of the azimuthally averaged radial
+    profile to evaluate the PSF at the geometric-mean FWHM radius
+    derived from the beam parameters.
+
+    If the PSF is a Gaussian, the skirt level should be exp(- 4 log(2)) = 0.0625.
+
+    Parameters
+    ----------
+    radii : numpy.ndarray
+        Radial bin centres in arcseconds.
+    psf_radial : numpy.ndarray
+        Azimuthally averaged PSF profile values at each radius.
+    bmaj : float
+        Beam major axis FWHM in arcseconds.
+    bmin : float
+        Beam minor axis FWHM in arcseconds.
+
+    Returns
+    -------
+    float or None
+        PSF value at the FWHM radius.
+    """
+    radii = np.asarray(radii, dtype=float)
+    psf_radial = np.asarray(psf_radial, dtype=float)
+
+    # Remove NaN bins (empty annuli at large radii)
+    valid = ~np.isnan(psf_radial)
+    radii = radii[valid]
+    psf_radial = psf_radial[valid]
+
+    if len(radii) == 0:
+        return None
+
+    fwhm = np.sqrt(bmaj * bmin)
+
+    if fwhm > radii[-1]:
+        logger.warning("FWHM exceeds radial profile extent; cannot compute skirt level")
+        return None
+
+    spline = UnivariateSpline(radii, psf_radial, s=0)
+    skirt_val = float(spline(fwhm))
+    return skirt_val
+
+
+def measure_epsilon(radii, psf_radial, bmaj, bmin):
+    """Compute epsilon, the ratio of clean beam to dirty beam flux.
+
+    Evaluates the ratio of the azimuthally integrated ideal Gaussian
+    beam to the azimuthally integrated dirty PSF, truncated at the
+    first null (zero crossing) of the radial profile. Values close
+    to 1 indicate a well-behaved PSF.
+
+    Parameters
+    ----------
+    radii : numpy.ndarray
+        Radial bin centres in arcseconds.
+    psf_radial : numpy.ndarray
+        Azimuthally averaged PSF profile values at each radius.
+    bmaj : float
+        Beam major axis FWHM in arcseconds.
+    bmin : float
+        Beam minor axis FWHM in arcseconds.
+
+    Returns
+    -------
+    float or None
+        The epsilon metric value.
+    """
+    radii = np.asarray(radii, dtype=float)
+    psf_radial = np.asarray(psf_radial, dtype=float)
+
+    # Remove NaN bins
+    valid = ~np.isnan(psf_radial)
+    radii = radii[valid]
+    psf_radial = psf_radial[valid]
+
+    if len(radii) == 0:
+        return None
+
+    sigma = np.sqrt(bmaj * bmin) / fwhm_factor
+
+    # Truncate at the first null (zero crossing)
+    null_idx = np.where(psf_radial <= 0)[0]
+    if len(null_idx) > 0:
+        radii = radii[:null_idx[0]]
+        psf_radial = psf_radial[:null_idx[0]]
+
+    if len(radii) == 0:
+        return None
+
+    # Gaussian model evaluated at the radial bin centres
+    gauss_profile = np.exp(-radii**2 / (2.0 * sigma**2))
+
+    # Azimuthal integration weight: 2*pi*r*dr
+    dr = np.gradient(radii)
+    psf_integral = np.sum(psf_radial * radii * dr)
+    gauss_integral = np.sum(gauss_profile * radii * dr)
+
+    if psf_integral == 0:
+        logger.warning("PSF integrates to zero; cannot compute epsilon")
+        return None
+
+    epsilon = float(gauss_integral / psf_integral)
+
+    return epsilon

--- a/phangsPipelineTests/test_utilsTestImagingPlots.py
+++ b/phangsPipelineTests/test_utilsTestImagingPlots.py
@@ -1,0 +1,193 @@
+"""Tests for PSF quality metrics in utilsTestImagingPlots.
+
+These tests verify that measure_kappa, measure_skirt_level, and
+measure_epsilon return the expected values when the PSF radial
+profile is a perfect Gaussian matching the beam parameters.
+
+For a perfect Gaussian:
+    - kappa should be 0 (no deviation from Gaussian within the FWHM)
+    - skirt_level should be exp(-4 log 2) ~ 0.0625
+    - epsilon should be 1 (clean beam = dirty beam)
+"""
+
+import unittest
+import numpy as np
+from phangsPipeline.utilsTestImagingPlots import (
+    measure_kappa,
+    measure_skirt_level,
+    measure_epsilon,
+    fwhm_factor,
+)
+
+
+def _make_gaussian_profile(bmaj, bmin, n_bins=500, max_radius_factor=3.0):
+    """Create a perfect Gaussian radial profile matching beam parameters.
+
+    Parameters
+    ----------
+    bmaj : float
+        Beam major axis FWHM in arcseconds.
+    bmin : float
+        Beam minor axis FWHM in arcseconds.
+    n_bins : int
+        Number of radial bins.
+    max_radius_factor : float
+        Profile extends to this factor times the geometric-mean FWHM.
+
+    Returns
+    -------
+    radii : numpy.ndarray
+        Radial bin centres in arcseconds.
+    profile : numpy.ndarray
+        Gaussian profile values.
+    """
+    fwhm = np.sqrt(bmaj * bmin)
+    sigma = fwhm / fwhm_factor
+    max_radius = max_radius_factor * fwhm
+    radii = np.linspace(0, max_radius, n_bins)
+    profile = np.exp(-radii**2 / (2.0 * sigma**2))
+    return radii, profile
+
+
+class TestMeasureKappa(unittest.TestCase):
+    """Tests for measure_kappa."""
+
+    def test_gaussian_kappa_is_zero(self):
+        """A perfect Gaussian PSF should have kappa = 0."""
+        bmaj, bmin = 5.0, 3.0
+        radii, profile = _make_gaussian_profile(bmaj, bmin)
+        kappa = measure_kappa(radii, profile, bmaj, bmin)
+        self.assertIsNotNone(kappa)
+        self.assertAlmostEqual(kappa, 0.0, places=4)
+
+    def test_gaussian_kappa_symmetric_beam(self):
+        """Circular beam should also give kappa = 0."""
+        bmaj, bmin = 4.0, 4.0
+        radii, profile = _make_gaussian_profile(bmaj, bmin)
+        kappa = measure_kappa(radii, profile, bmaj, bmin)
+        self.assertIsNotNone(kappa)
+        self.assertAlmostEqual(kappa, 0.0, places=4)
+
+    def test_peaked_psf_negative_kappa(self):
+        """A PSF more peaked than the Gaussian should give kappa < 0."""
+        bmaj, bmin = 5.0, 3.0
+        radii, profile = _make_gaussian_profile(bmaj, bmin)
+        # Make core more peaked by raising to a power > 1
+        peaked = profile ** 1.5
+        kappa = measure_kappa(radii, peaked, bmaj, bmin)
+        self.assertIsNotNone(kappa)
+        self.assertLess(kappa, 0.0)
+
+    def test_flat_psf_positive_kappa(self):
+        """A PSF flatter than the Gaussian should give kappa > 0."""
+        bmaj, bmin = 5.0, 3.0
+        radii, profile = _make_gaussian_profile(bmaj, bmin)
+        # Make core flatter by raising to a power < 1
+        flat = profile ** 0.5
+        kappa = measure_kappa(radii, flat, bmaj, bmin)
+        self.assertIsNotNone(kappa)
+        self.assertGreater(kappa, 0.0)
+
+    def test_empty_input_returns_none(self):
+        """Empty arrays should return None."""
+        kappa = measure_kappa(np.array([]), np.array([]), 5.0, 3.0)
+        self.assertIsNone(kappa)
+
+    def test_all_nan_returns_none(self):
+        """All-NaN profile should return None."""
+        radii = np.linspace(0, 10, 100)
+        profile = np.full_like(radii, np.nan)
+        kappa = measure_kappa(radii, profile, 5.0, 3.0)
+        self.assertIsNone(kappa)
+
+
+class TestMeasureSkirtLevel(unittest.TestCase):
+    """Tests for measure_skirt_level."""
+
+    def test_gaussian_skirt_level(self):
+        """A perfect Gaussian should give skirt_level = exp(-4 log 2) ~ 0.0625."""
+        expected = np.exp(-4.0 * np.log(2.0))
+        bmaj, bmin = 5.0, 3.0
+        radii, profile = _make_gaussian_profile(bmaj, bmin)
+        skirt = measure_skirt_level(radii, profile, bmaj, bmin)
+        self.assertIsNotNone(skirt)
+        self.assertAlmostEqual(skirt, expected, places=3)
+
+    def test_gaussian_skirt_level_circular(self):
+        """Circular beam should also give skirt ~ 0.0625."""
+        expected = np.exp(-4.0 * np.log(2.0))
+        bmaj, bmin = 6.0, 6.0
+        radii, profile = _make_gaussian_profile(bmaj, bmin)
+        skirt = measure_skirt_level(radii, profile, bmaj, bmin)
+        self.assertIsNotNone(skirt)
+        self.assertAlmostEqual(skirt, expected, places=3)
+
+    def test_broader_wings_higher_skirt(self):
+        """PSF with broader wings should have skirt > 0.0625."""
+        expected = np.exp(-4.0 * np.log(2.0))
+        bmaj, bmin = 5.0, 3.0
+        radii, profile = _make_gaussian_profile(bmaj, bmin)
+        # Broaden the wings: raise to power < 1
+        broad = profile ** 0.7
+        skirt = measure_skirt_level(radii, broad, bmaj, bmin)
+        self.assertIsNotNone(skirt)
+        self.assertGreater(skirt, expected)
+
+    def test_empty_input_returns_none(self):
+        """Empty arrays should return None."""
+        skirt = measure_skirt_level(np.array([]), np.array([]), 5.0, 3.0)
+        self.assertIsNone(skirt)
+
+
+class TestMeasureEpsilon(unittest.TestCase):
+    """Tests for measure_epsilon."""
+
+    def test_gaussian_epsilon_is_one(self):
+        """A perfect Gaussian PSF should give epsilon = 1."""
+        bmaj, bmin = 5.0, 3.0
+        radii, profile = _make_gaussian_profile(bmaj, bmin)
+        eps = measure_epsilon(radii, profile, bmaj, bmin)
+        self.assertIsNotNone(eps)
+        self.assertAlmostEqual(eps, 1.0, places=3)
+
+    def test_gaussian_epsilon_circular(self):
+        """Circular beam should also give epsilon = 1."""
+        bmaj, bmin = 4.0, 4.0
+        radii, profile = _make_gaussian_profile(bmaj, bmin)
+        eps = measure_epsilon(radii, profile, bmaj, bmin)
+        self.assertIsNotNone(eps)
+        self.assertAlmostEqual(eps, 1.0, places=3)
+
+    def test_excess_sidelobe_epsilon_below_one(self):
+        """PSF with excess flux (wider wings) should give epsilon < 1."""
+        bmaj, bmin = 5.0, 3.0
+        radii, profile = _make_gaussian_profile(bmaj, bmin)
+        # Add extra flux in the wings
+        excess = profile + 0.1 * np.exp(-radii / 5.0)
+        excess /= excess[0]  # re-normalise peak to 1
+        eps = measure_epsilon(radii, excess, bmaj, bmin)
+        self.assertIsNotNone(eps)
+        self.assertLess(eps, 1.0)
+
+    def test_empty_input_returns_none(self):
+        """Empty arrays should return None."""
+        eps = measure_epsilon(np.array([]), np.array([]), 5.0, 3.0)
+        self.assertIsNone(eps)
+
+    def test_profile_with_null(self):
+        """Profile that crosses zero should still compute epsilon."""
+        bmaj, bmin = 5.0, 3.0
+        fwhm = np.sqrt(bmaj * bmin)
+        sigma = fwhm / fwhm_factor
+        radii = np.linspace(0, 3.0 * fwhm, 500)
+        # Gaussian core with a negative trough beyond the FWHM
+        profile = np.exp(-radii**2 / (2.0 * sigma**2))
+        profile[radii > 1.5 * fwhm] = -0.05
+        eps = measure_epsilon(radii, profile, bmaj, bmin)
+        self.assertIsNotNone(eps)
+        # Should be close to 1 since the Gaussian core is identical
+        self.assertAlmostEqual(eps, 1.0, delta=0.05)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/run_casa_test_imaging_example.py
+++ b/run_casa_test_imaging_example.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python
+#
+# Run this script INSIDE CASA or with CASA available.
+#
+
+# This is the PHANGS ALMA staging and imaging script.
+
+# This script loads the project data, constructs the PHANGS pipeline
+# handlers, and then executes each step: staging, imaging,
+# postprocessing. The user has control over which targets, spectral
+# products, and steps run.
+
+# This is a documented version that we provide with the main pipeline
+# repository as an example tou users. You should be able to modify
+# this script to get a good start on your own wrapper to the pipeline.
+
+
+##############################################################################
+# Load routines, initialize handlers
+##############################################################################
+
+import os
+import sys
+
+import numpy as np
+
+# Append analysisUtils
+sys.path.append("/PATH/analysis_scripts")
+import analysisUtils as au
+
+sys.path.append("/PATH/phangs_imaging_scripts")
+
+# Location of the master key. Set this to the master key that points
+# to all of the keys for your project.
+
+key_file = 'PATH/keys/master_key.txt'
+
+# Import the logger and initialize the logging. You can change the
+# level of message that you want to see by changing "level" here or
+# save to a logfile with the keyword.
+
+from phangsPipeline import phangsLogger as pl
+pl.setup_logger(level='DEBUG', logfile=None)
+
+# Imports
+
+from phangsPipeline import handlerKeys as kh
+from phangsPipeline import handlerVis as uvh
+
+from phangsPipeline import handlerTestImaging as tih
+
+
+# Initialize the various handler objects. First initialize the
+# KeyHandler, which reads the master key and the files linked in the
+# master key. Then feed this keyHandler, which has all the project
+# data, into the other handlers (VisHandler, ImagingHandler,
+# PostProcessHandler), which run the actual pipeline using the project
+# definitions from the KeyHandler.
+
+this_kh = kh.KeyHandler(master_key=key_file)
+this_uvh = uvh.VisHandler(key_handler=this_kh)
+
+# Make any missing directories
+this_kh.make_missing_directories(imaging=True, derived=True, postprocess=True, release=True)
+
+##############################################################################
+# Set up what we do this run
+##############################################################################
+
+
+# Set the configs (arrays), spectral products (lines), and targets to
+# consider.
+
+# Set the targets. Called with only () it will use all targets. The
+# only= , just= , start= , stop= criteria allow one to build a smaller
+# list.
+
+# Set the configs. Set both interf_configs and feather_configs just to
+# determine which cubes will be processed. The only effect in this
+# derive product calculation is to determine which cubes get fed into
+# the calculation.
+
+# Set the line products. Similarly, this just determines which cubes
+# are fed in. Right now there's no derived product pipeline focused on
+# continuum maps.
+
+# ASIDE: In PHANGS-ALMA we ran a cheap parallelization by running
+# several scripts with different start and stop values in parallel. If
+# you are running a big batch of jobs you might consider scripting
+# something similar.
+
+# Note here that we need to set the targets, configs, and lines for
+# *all three* relevant handlers - the VisHandler (uvh), ImagingHandler
+# (imh), and PostprocessHandler (pph). The settings below will stage
+# combined 12m+7m data sets (including staging C18O and continuum),
+# image the CO 2-1 line from these, and then postprocess the CO 2-1
+# cubes.
+
+this_uvh.set_targets()
+this_uvh.set_interf_configs(only=['A+B+C'])
+this_uvh.set_line_products(only=['hilores'])
+this_uvh.set_no_cont_products(False)
+
+# e.g., could be to be more selective:
+# this_uvh.set_targets(only=['ngc3489','ngc3599','ngc4476'])
+# this_uvh.set_interf_configs(only=['A+B+C'])
+# this_uvh.set_line_products(only=['co21'])
+
+# this_imh.set_targets()
+# this_imh.set_interf_configs(only=['A+B+C'])
+# this_imh.set_no_cont_products(True)
+# this_imh.set_line_products(only=['hilores'])
+
+# Use boolean flags to set the steps to be performed when the pipeline
+# is called. See descriptions below (but only edit here).
+
+do_staging = True
+do_imaging_tests = True
+
+##############################################################################
+# Run staging
+##############################################################################
+
+# "Stage" the visibility data. This involves copying the original
+# calibrated measurement set, continuum subtracting (if requested),
+# extraction of requested lines and continuum data, regridding and
+# concatenation into a single measurement set. The overwrite=True flag
+# is needed to ensure that previous runs can be overwritten.
+
+if do_staging:
+    this_uvh.loop_stage_uvdata(do_copy=True, do_contsub=True,
+                               do_extract_line=False, do_extract_cont=False,
+                               do_remove_staging=False, overwrite=True,
+                               strict_config=False)
+
+    this_uvh.loop_stage_uvdata(do_copy=False, do_contsub=False,
+                               do_extract_line=True, do_extract_cont=False,
+                               do_remove_staging=False, overwrite=True,
+                               strict_config=False)
+
+    # this_uvh.loop_stage_uvdata(do_copy=False, do_contsub=False,
+    #                            do_extract_line=False, do_extract_cont=True,
+    #                            do_remove_staging=False, overwrite=True,
+    #                            strict_config=False)
+
+    # this_uvh.loop_stage_uvdata(do_copy=False, do_contsub=False,
+    #                            do_extract_line=False, do_extract_cont=False,
+    #                            do_remove_staging=True, overwrite=True,
+    #                            strict_config=False)
+
+##############################################################################
+# Step through imaging
+##############################################################################
+
+# Image the concatenated, regridded visibility data. The full loop
+# involves applying any user-supplied clean mask, multiscale imaging,
+# mask generation for the single scale clean, and single scale
+# clean. The individual parts can be turned on or off with flags to
+# the imaging loop call but this call does everything.
+
+if do_imaging_tests:
+
+
+    this_tih = tih.TestImagingHandler(key_handler = this_kh)
+
+    this_tih.set_interf_configs(only=['A+B+C'])
+    this_tih.set_line_products(only=['hilores'])
+
+
+    # Define test parameters
+    this_tih.set_test_params(
+        weightings=['uniform', 'briggs', 'briggs', 'natural', 'briggs', 'natural'],
+        robustnums=[None, 0.5, 2.0, None, 0.5, None],
+        tapers_arcsec=[0.0, 0.0, 1.0, 0.0, 1.0, 5.0],
+    )
+
+    # Example of using a range of robust values
+    # robusts = np.round(np.arange(-2.0, 2.1, 0.4), 2)
+
+    # this_tih.set_test_params(
+    #     weightings=['briggs'] * len(robusts),
+    #     robustnums=robusts,
+    #     tapers_arcsec=None,
+    # )
+
+    # Run the test imaging loop
+    # To remake any images, set overwrite=True
+    results = this_tih.loop_test_imaging(overwrite=False)
+
+    # Generate all diagnostic plots and export CSV in one call
+    # Exports an HTML report showing the results table and diagnostic plots
+    # together.
+    this_tih.make_report()
+
+    # Print summary
+    this_tih.print_summary()
+
+    # Create summary CSV
+    this_tih.export_summary_csv()
+
+    # Suggested weighting:
+    suggestion = this_tih.suggest_optimal(target_resolution_arcsec=6.0)


### PR DESCRIPTION
Add TestImagingHandler and associated utilities to test different gridding parameters and generate a summary report.

This provides a method to create several image versions and quantify different PSF shape metrics. This is done by selecting a single channel only for lines with no deconvolution. By default the first channel is used, assuming the staged MS parameters pads the velocity range a bit and the first channel will have no signal (for a reliable RMS estimate).