### PR TITLE
Shuffled cubes and flat maps implementation

### DIFF
--- a/example_make_products.py
+++ b/example_make_products.py
@@ -9,130 +9,150 @@ import numpy as np
 import scConvolution as scc
 import scNoiseRoutines as scn
 import scMaskingRoutines as scm
+import scStackingRoutines as scs
 import scMoments as sco
 from astropy import units as u
+
+# region Definitions/tuning
 
 # ####################################################
 # Definitions/tuning
 # ####################################################
 
 working_dir = '../working_data/'
+vfield_dir = '../velocity_fields/'
 
-infile = '12co10-05kms-d-30m-clean.fits'
+infile = 'ngc4321_12m+7m+tp_co21.fits'
 
-outfile = 'ic342_noema+30m_co10_5kms.fits'
-
-dist = "3.45Mpc"
+dist = "15.21Mpc"
 target_angular = ['8arcsec','15arcsec','21arcsec']
 target_physical = ['150pc','500pc','1000pc','1500pc']
+
+# velocity vfield map used for shuffling
+vfield_infile = 'ngc4321_vfield.fits'
+window = '50km/s' # velocity window for masking
+
+# Use boolean flags to set the steps to be performed when the pipeline
+# is called. See descriptions below (but only edit here).
+
+do_convolve = True
+do_noise = True
+do_strictmask = True
+do_broadmask = True
+do_moments = True
+# new DR5 routines for shuffling and flat maps
+do_vfield = False # run this if you don't have a velocity field
+do_shuffling = True
+do_flatmask = True
+do_flatmaps = True
+
+# endregion
+
+# region Convolution
 
 # ####################################################
 # Convolution
 # ####################################################
 
-this_infile = working_dir+outfile[ii]
+if do_convolve:
 
-for this_ext in target_angular:
-    print("Convolution to "+this_ext)
-    this_outfile = this_infile.replace('.fits','_'+this_ext+'.fits')
-    scc.smooth_cube(
-        incube=this_infile,
-        outfile=this_outfile,
-        angular_resolution=this_ext,
-        linear_resolution=None,
-        distance=None,
-        velocity_resolution=None,
-        nan_treatment='interpolate',
-        tol=None,
-        make_coverage_cube=True,
-        collapse_coverage=True,
-        coveragefile=this_outfile.replace('.fits','_coverage.fits'),
-        coverage2dfile=this_outfile.replace('.fits','_coverage2d.fits'),
-        dtype=np.float32,
-        overwrite=True
-    )
+    this_infile = working_dir+infile
 
-for this_ext in target_physical:
-    print("Convolution to "+this_ext)
-    this_outfile = this_infile.replace('.fits','_'+this_ext+'.fits')
-    scc.smooth_cube(
-        incube=this_infile,
-        outfile=this_outfile,
-        angular_resolution=None,
-        linear_resolution=this_ext,
-        distance=dist,
-        velocity_resolution=None,
-        nan_treatment='interpolate',
-        tol=None,
-        make_coverage_cube=True,
-        collapse_coverage=True,
-        coveragefile=this_outfile.replace('.fits','_coverage.fits'),
-        coverage2dfile=this_outfile.replace('.fits','_coverage2d.fits'),
-        dtype=np.float32,
-        overwrite=True
-    )
+    # angular resolutions
+    for this_ext in target_angular:
+        print("Convolution to "+this_ext)
+        this_outfile = this_infile.replace('.fits','_'+this_ext+'.fits')
+        scc.smooth_cube(
+            incube=this_infile,
+            outfile=this_outfile,
+            angular_resolution=this_ext,
+            linear_resolution=None,
+            distance=None,
+            velocity_resolution=None,
+            nan_treatment='interpolate',
+            tol=None,
+            make_coverage_cube=True,
+            collapse_coverage=True,
+            coveragefile=this_outfile.replace('.fits','_coverage.fits'),
+            coverage2dfile=this_outfile.replace('.fits','_coverage2d.fits'),
+            dtype=np.float32,
+            overwrite=True
+        )
+
+    # physical resolutions
+    for this_ext in target_physical:
+        print("Convolution to "+this_ext)
+        this_outfile = this_infile.replace('.fits','_'+this_ext+'.fits')
+        scc.smooth_cube(
+            incube=this_infile,
+            outfile=this_outfile,
+            angular_resolution=None,
+            linear_resolution=this_ext,
+            distance=dist,
+            velocity_resolution=None,
+            nan_treatment='interpolate',
+            tol=None,
+            make_coverage_cube=True,
+            collapse_coverage=True,
+            coveragefile=this_outfile.replace('.fits','_coverage.fits'),
+            coverage2dfile=this_outfile.replace('.fits','_coverage2d.fits'),
+            dtype=np.float32,
+            overwrite=True
+        )
+
+# endregion
+
+# region Noise Estimation
 
 # ####################################################
 # Noise Estimation
 # ####################################################
 
-# native
-this_base_infile = working_dir+outfile[ii]
-print("Noise native res for ", this_base_infile)
-scn.recipe_phangs_noise(
-    incube=this_base_infile,
-    outfile=this_base_infile.replace('.fits','_noise.fits'),
-    overwrite=True)
-    
-# angular resolutions
-for this_ext in target_angular:
-    this_infile = this_base_infile.replace('.fits','_'+this_ext+'.fits')
-    print("Noise for "+this_ext, this_infile)
+if do_noise:
+        
+    # native resolution
+    this_base_infile = working_dir+infile
+    print("Noise native res for ", this_base_infile)
     scn.recipe_phangs_noise(
-        incube=this_infile,
-        outfile=this_infile.replace('.fits','_noise.fits'),
+        incube=this_base_infile,
+        outfile=this_base_infile.replace('.fits','_noise.fits'),
         overwrite=True)
+        
+    # angular resolutions
+    for this_ext in target_angular:
+        this_infile = this_base_infile.replace('.fits','_'+this_ext+'.fits')
+        print("Noise for "+this_ext, this_infile)
+        scn.recipe_phangs_noise(
+            incube=this_infile,
+            outfile=this_infile.replace('.fits','_noise.fits'),
+            overwrite=True)
 
-# physical resolutions
-for this_ext in target_physical:
-    this_infile = this_base_infile.replace('.fits','_'+this_ext+'.fits')
-    print("Noise for "+this_ext, this_infile)
-    scn.recipe_phangs_noise(
-        incube=this_infile,
-        outfile=this_infile.replace('.fits','_noise.fits'),
-        overwrite=True)
+    # physical resolutions
+    for this_ext in target_physical:
+        this_infile = this_base_infile.replace('.fits','_'+this_ext+'.fits')
+        print("Noise for "+this_ext, this_infile)
+        scn.recipe_phangs_noise(
+            incube=this_infile,
+            outfile=this_infile.replace('.fits','_noise.fits'),
+            overwrite=True)
+
+# endregion
+
+# region Strict Mask Creation
 
 # ####################################################
 # Strict Mask Creation
 # ####################################################
 
-mask_kwargs = {'hi_thresh':5.0, 'lo_thresh':2.0, 
-               'hi_nchan':2, 'lo_nchan':2}
+if do_strictmask:
 
-this_base_infile = working_dir+outfile[ii]
+    mask_kwargs = {'hi_thresh':5.0, 'lo_thresh':2.0, 
+                'hi_nchan':2, 'lo_nchan':2}
 
-# native
-this_infile = this_base_infile
-print("Strict mask for ", this_infile)
-scm.recipe_phangs_strict_mask(
-    this_infile, 
-    this_infile.replace('.fits','_noise.fits'),
-    outfile=this_infile.replace('.fits','_strictmask.fits'),
-    mask_kwargs=mask_kwargs,
-    overwrite=True)
+    this_base_infile = working_dir+infile
 
-for this_ext in target_angular:
-    this_infile = this_base_infile.replace('.fits','_'+this_ext+'.fits')
-    print("Strict mask for ", this_infile)
-    scm.recipe_phangs_strict_mask(
-        this_infile,
-        this_infile.replace('.fits','_noise.fits'),
-        outfile=this_infile.replace('.fits','_strictmask.fits'),
-        mask_kwargs=mask_kwargs,
-        overwrite=True)
-
-for this_ext in target_physical:
-    this_infile = this_base_infile.replace('.fits','_'+this_ext+'.fits')
+    # native resolution
+    this_infile = this_base_infile
     print("Strict mask for ", this_infile)
     scm.recipe_phangs_strict_mask(
         this_infile, 
@@ -140,117 +160,131 @@ for this_ext in target_physical:
         outfile=this_infile.replace('.fits','_strictmask.fits'),
         mask_kwargs=mask_kwargs,
         overwrite=True)
+
+    # angular resolutions
+    for this_ext in target_angular:
+        this_infile = this_base_infile.replace('.fits','_'+this_ext+'.fits')
+        print("Strict mask for ", this_infile)
+        scm.recipe_phangs_strict_mask(
+            this_infile,
+            this_infile.replace('.fits','_noise.fits'),
+            outfile=this_infile.replace('.fits','_strictmask.fits'),
+            mask_kwargs=mask_kwargs,
+            overwrite=True)
+
+    # physical resolutions
+    for this_ext in target_physical:
+        this_infile = this_base_infile.replace('.fits','_'+this_ext+'.fits')
+        print("Strict mask for ", this_infile)
+        scm.recipe_phangs_strict_mask(
+            this_infile, 
+            this_infile.replace('.fits','_noise.fits'),
+            outfile=this_infile.replace('.fits','_strictmask.fits'),
+            mask_kwargs=mask_kwargs,
+            overwrite=True)
     
+# endregion
+
+# region Broad Mask Creation
+
 # ####################################################
 # Broad Mask Creation
 # ####################################################
 
-this_base_infile = working_dir+outfile[ii]
-template_mask = this_base_infile.replace('.fits','_strictmask.fits')
-broad_mask_file = this_base_infile.replace('.fits','_broadmask.fits')
+if do_broadmask:
 
-list_of_masks = [template_mask]
+    this_base_infile = working_dir+infile
+    template_mask = this_base_infile.replace('.fits','_strictmask.fits')
+    broad_mask_file = this_base_infile.replace('.fits','_broadmask.fits')
 
-for this_ext in target_angular:
-    this_infile = this_base_infile.replace('.fits','_'+this_ext+'.fits')
-    this_mask = this_infile.replace('.fits','_strictmask.fits')
-    list_of_masks.append(this_mask)
-    
-for this_ext in target_physical:
-    this_infile = this_base_infile.replace('.fits','_'+this_ext+'.fits')
-    this_mask = this_infile.replace('.fits','_strictmask.fits')
-    list_of_masks.append(this_mask)
-    
-scm.recipe_phangs_broad_mask(
-    template_mask, 
-    outfile=broad_mask_file, 
-    list_of_masks = list_of_masks,
-    grow_xy = 2, 
-    grow_v = 2,
-    return_spectral_cube=False, overwrite=True,
-    recipe='anyscale', fraction_of_scales=0.25)
- 
+    list_of_masks = [template_mask]
+
+    for this_ext in target_angular:
+        this_infile = this_base_infile.replace('.fits','_'+this_ext+'.fits')
+        this_mask = this_infile.replace('.fits','_strictmask.fits')
+        list_of_masks.append(this_mask)
+        
+    for this_ext in target_physical:
+        this_infile = this_base_infile.replace('.fits','_'+this_ext+'.fits')
+        this_mask = this_infile.replace('.fits','_strictmask.fits')
+        list_of_masks.append(this_mask)
+        
+    scm.recipe_phangs_broad_mask(
+        template_mask, 
+        outfile=broad_mask_file, 
+        list_of_masks = list_of_masks,
+        grow_xy = 2, 
+        grow_v = 2,
+        return_spectral_cube=False, overwrite=True,
+        recipe='anyscale', fraction_of_scales=0.25)
+
+# endregion
+
+# region Moments
+
 # ####################################################
 # Moments
 # ####################################################
 
-mom_list = {
-    'strictmom0':{
-        'algorithm':'mom0',
-        'mask':'_strictmask.fits',
-        'ext':'_strict_mom0.fits',
-        'ext_error':'_strict_emom0.fits',
-        'kwargs':{},
-        },
-    'broadmom0':{
-        'algorithm':'mom0',
-        'mask':'_broadmask.fits',
-        'ext':'_broad_mom0.fits',
-        'ext_error':'_broad_emom0.fits',
-        'kwargs':{},
-        },
-    'strictmom1':{
-        'algorithm':'mom1',
-        'mask':'_strictmask.fits',
-        'ext':'_strict_mom1.fits',
-        'ext_error':'_strict_emom1.fits',
-        'kwargs':{},
-        },
-    'broadmom1':{
-        'algorithm':'mom1',
-        'mask':'_broadmask.fits',
-        'ext':'_broad_mom1.fits',
-        'ext_error':'_broad_emom1.fits',
-        'kwargs':{},
-        },
-    'strictmom2':{
-        'algorithm':'mom2',
-        'mask':'_strictmask.fits',
-        'ext':'_strict_mom2.fits',
-        'ext_error':'_strict_emom2.fits',
-        'kwargs':{},
-        },
-    'strictew':{
-        'algorithm':'ew',
-        'mask':'_strictmask.fits',
-        'ext':'_strict_ew.fits',
-        'ext_error':'_strict_eew.fits',
-        'kwargs':{},
-        },
-    'tpeak':{
-        'algorithm':'tpeak',
-        'mask':'_broadmask.fits',
-        'ext':'_broad_tpeak.fits',
-        'ext_error':'_broad_etpeak.fits',
-        'kwargs':{},
-        },
-    }
+if do_moments:
 
-# native
-this_base_infile = working_dir+outfile[ii]
-this_infile = this_base_infile
-print("Moments for ", this_infile)
+    mom_list = {
+        'strictmom0':{
+            'algorithm':'mom0',
+            'mask':'_strictmask.fits',
+            'ext':'_strict_mom0.fits',
+            'ext_error':'_strict_emom0.fits',
+            'kwargs':{},
+            },
+        'broadmom0':{
+            'algorithm':'mom0',
+            'mask':'_broadmask.fits',
+            'ext':'_broad_mom0.fits',
+            'ext_error':'_broad_emom0.fits',
+            'kwargs':{},
+            },
+        'strictmom1':{
+            'algorithm':'mom1',
+            'mask':'_strictmask.fits',
+            'ext':'_strict_mom1.fits',
+            'ext_error':'_strict_emom1.fits',
+            'kwargs':{},
+            },
+        'broadmom1':{
+            'algorithm':'mom1',
+            'mask':'_broadmask.fits',
+            'ext':'_broad_mom1.fits',
+            'ext_error':'_broad_emom1.fits',
+            'kwargs':{},
+            },
+        'strictmom2':{
+            'algorithm':'mom2',
+            'mask':'_strictmask.fits',
+            'ext':'_strict_mom2.fits',
+            'ext_error':'_strict_emom2.fits',
+            'kwargs':{},
+            },
+        'strictew':{
+            'algorithm':'ew',
+            'mask':'_strictmask.fits',
+            'ext':'_strict_ew.fits',
+            'ext_error':'_strict_eew.fits',
+            'kwargs':{},
+            },
+        'tpeak':{
+            'algorithm':'tpeak',
+            'mask':'_broadmask.fits',
+            'ext':'_broad_tpeak.fits',
+            'ext_error':'_broad_etpeak.fits',
+            'kwargs':{},
+            },
+        }
 
-for this_mom_key in mom_list:      
-    this_mom = mom_list[this_mom_key]
-    if this_mom['mask'] == '_broadmask.fits':
-        this_mask_file = this_base_infile.replace('.fits',this_mom['mask'])
-    else:
-        this_mask_file = this_infile.replace('.fits',this_mom['mask'])
-    this_noise_file = this_infile.replace('.fits','_noise.fits')
-    this_out_file = this_infile.replace('.fits',this_mom['ext'])
-    this_error_file = this_infile.replace('.fits',this_mom['ext_error'])
-    sco.moment_generator(
-        this_infile,
-        mask=this_mask_file, noise=this_noise_file,
-        moment=this_mom['algorithm'], momkwargs=this_mom['kwargs'],
-        outfile=this_out_file, errorfile=this_error_file,
-        channel_correlation=None,
-    )
+    # native resolution
+    this_base_infile = working_dir+infile
+    this_infile = this_base_infile
+    print("Moments for ", this_infile)
 
-# angular resolutions
-for this_ext in target_angular:
-    this_infile = this_base_infile.replace('.fits','_'+this_ext+'.fits')
     for this_mom_key in mom_list:      
         this_mom = mom_list[this_mom_key]
         if this_mom['mask'] == '_broadmask.fits':
@@ -268,23 +302,272 @@ for this_ext in target_angular:
             channel_correlation=None,
         )
 
-# physical resolutions
-for this_ext in target_physical:
-    this_infile = this_base_infile.replace('.fits','_'+this_ext+'.fits')
-    for this_mom_key in mom_list:      
-        this_mom = mom_list[this_mom_key]
-        if this_mom['mask'] == '_broadmask.fits':
-            this_mask_file = this_base_infile.replace('.fits',this_mom['mask'])
-        else:
-            this_mask_file = this_infile.replace('.fits',this_mom['mask'])
-        this_noise_file = this_infile.replace('.fits','_noise.fits')
-        this_out_file = this_infile.replace('.fits',this_mom['ext'])
-        this_error_file = this_infile.replace('.fits',this_mom['ext_error'])
-        sco.moment_generator(
-            this_infile,
-            mask=this_mask_file, noise=this_noise_file,
-            moment=this_mom['algorithm'], momkwargs=this_mom['kwargs'],
-            outfile=this_out_file, errorfile=this_error_file,
-            channel_correlation=None,
-        )
+    # angular resolutions
+    for this_ext in target_angular:
+        this_infile = this_base_infile.replace('.fits','_'+this_ext+'.fits')
+        for this_mom_key in mom_list:      
+            this_mom = mom_list[this_mom_key]
+            if this_mom['mask'] == '_broadmask.fits':
+                this_mask_file = this_base_infile.replace('.fits',this_mom['mask'])
+            else:
+                this_mask_file = this_infile.replace('.fits',this_mom['mask'])
+            this_noise_file = this_infile.replace('.fits','_noise.fits')
+            this_out_file = this_infile.replace('.fits',this_mom['ext'])
+            this_error_file = this_infile.replace('.fits',this_mom['ext_error'])
+            sco.moment_generator(
+                this_infile,
+                mask=this_mask_file, noise=this_noise_file,
+                moment=this_mom['algorithm'], momkwargs=this_mom['kwargs'],
+                outfile=this_out_file, errorfile=this_error_file,
+                channel_correlation=None,
+            )
+
+    # physical resolutions
+    for this_ext in target_physical:
+        this_infile = this_base_infile.replace('.fits','_'+this_ext+'.fits')
+        for this_mom_key in mom_list:      
+            this_mom = mom_list[this_mom_key]
+            if this_mom['mask'] == '_broadmask.fits':
+                this_mask_file = this_base_infile.replace('.fits',this_mom['mask'])
+            else:
+                this_mask_file = this_infile.replace('.fits',this_mom['mask'])
+            this_noise_file = this_infile.replace('.fits','_noise.fits')
+            this_out_file = this_infile.replace('.fits',this_mom['ext'])
+            this_error_file = this_infile.replace('.fits',this_mom['ext_error'])
+            sco.moment_generator(
+                this_infile,
+                mask=this_mask_file, noise=this_noise_file,
+                moment=this_mom['algorithm'], momkwargs=this_mom['kwargs'],
+                outfile=this_out_file, errorfile=this_error_file,
+                channel_correlation=None,
+            )
+            
+# endregion
+
+# region Velocity Field
+
+# ####################################################
+# Velocity Field
+# ####################################################
+
+if do_vfield:
+
+    this_base_infile = working_dir+infile
+    template_vfield = this_base_infile.replace('.fits','_strict_mom1.fits')
+    vfield_file = this_base_infile.replace('.fits','_vfield.fits')
+
+    list_of_vfields = [template_vfield]
+
+    for this_ext in target_angular:
+        this_infile = this_base_infile.replace('.fits','_'+this_ext+'.fits')
+        this_vfield = this_infile.replace('.fits','_strict_mom1.fits')
+        list_of_vfields.append(this_vfield)
         
+    for this_ext in target_physical:
+        this_infile = this_base_infile.replace('.fits','_'+this_ext+'.fits')
+        this_vfield = this_infile.replace('.fits','_strict_mom1.fits')
+        list_of_vfields.append(this_vfield)
+        
+    scs.recipe_phangs_vfield(
+        template_vfield, 
+        outfile=vfield_file, 
+        list_of_vfields = list_of_vfields,
+        overwrite=True)
+       
+    
+# endregion
+
+# region Shuffling
+
+# ####################################################
+# Shuffling
+# ####################################################
+
+if do_shuffling:
+
+    # native resolution
+    this_base_infile = working_dir+infile
+    this_vfield_infile = vfield_dir+vfield_infile
+    print("Shuffling ", this_base_infile)
+    scs.recipe_shuffle_cube(
+        incube=this_base_infile,
+        invfield=this_vfield_infile,
+        outfile=this_base_infile.replace('.fits','_shuffled.fits'),
+        overwrite=True)
+
+# endregion
+
+
+# region Flat Mask Creation
+
+# ####################################################
+# Flat Mask Creation
+# ####################################################
+
+
+if do_flatmask:
+
+    mask_kwargs = {'window':window}
+    this_base_infile = working_dir+infile
+    this_vfield_infile = vfield_dir+vfield_infile
+
+    # native resolution
+    this_infile = this_base_infile
+    # strict version
+    this_mask = this_infile.replace('.fits','_strictmask.fits')
+    print("Flat strict mask for ", this_infile)
+    scm.recipe_phangs_flat_mask(
+        this_infile, 
+        this_vfield_infile, 
+        this_mask, 
+        outfile=this_infile.replace('.fits','_flatstrictmask.fits'),
+        mask_kwargs=mask_kwargs,
+        return_spectral_cube=False,
+        overwrite=True)
+    # broad version
+    this_mask = this_infile.replace('.fits','_broadmask.fits')
+    print("Flat broad mask for ", this_infile)
+    scm.recipe_phangs_flat_mask(
+        this_infile, 
+        this_vfield_infile, 
+        this_mask, 
+        outfile=this_infile.replace('.fits','_flatbroadmask.fits'),
+        mask_kwargs=mask_kwargs,
+        return_spectral_cube=False,
+        overwrite=True)
+    
+    # angular resolutions
+    for this_ext in target_angular:
+        this_infile = this_base_infile.replace('.fits','_'+this_ext+'.fits')
+        # strict version
+        this_mask = this_infile.replace('.fits','_strictmask.fits')
+        print("Flat strict mask for ", this_infile)
+        scm.recipe_phangs_flat_mask(
+            this_infile, 
+            this_vfield_infile, 
+            this_mask, 
+            outfile=this_infile.replace('.fits','_flatstrictmask.fits'),
+            mask_kwargs=mask_kwargs,
+            return_spectral_cube=False,
+            overwrite=True)
+        # broad version
+        this_mask = this_base_infile.replace('.fits','_broadmask.fits')
+        print("Flat broad mask for ", this_infile)
+        scm.recipe_phangs_flat_mask(
+            this_infile, 
+            this_vfield_infile, 
+            this_mask, 
+            outfile=this_infile.replace('.fits','_flatbroadmask.fits'),
+            mask_kwargs=mask_kwargs,
+            return_spectral_cube=False,
+            overwrite=True)
+        
+    # physical resolutions
+    for this_ext in target_physical:
+        this_infile = this_base_infile.replace('.fits','_'+this_ext+'.fits')
+        # strict version
+        this_mask = this_infile.replace('.fits','_strictmask.fits')
+        print("Flat strict mask for ", this_infile)
+        scm.recipe_phangs_flat_mask(
+            this_infile, 
+            this_vfield_infile, 
+            this_mask, 
+            outfile=this_infile.replace('.fits','_flatstrictmask.fits'),
+            mask_kwargs=mask_kwargs,
+            return_spectral_cube=False,
+            overwrite=True)
+        # broad version
+        this_mask = this_base_infile.replace('.fits','_broadmask.fits')
+        print("Flat broad mask for ", this_infile)
+        scm.recipe_phangs_flat_mask(
+            this_infile, 
+            this_vfield_infile, 
+            this_mask, 
+            outfile=this_infile.replace('.fits','_flatbroadmask.fits'),
+            mask_kwargs=mask_kwargs,
+            return_spectral_cube=False,
+            overwrite=True)
+
+# endregion
+
+# region Flat Maps
+
+# ####################################################
+# Flat Maps
+# ####################################################
+
+if do_flatmaps:
+
+    mom_list = {
+        'flatstrictmom0':
+            {
+            'algorithm':'mom0',
+            'mask':'_flatstrictmask.fits',
+            'ext':'_flatstrict_mom0.fits',
+            'ext_error':'_flatstrict_emom0.fits',
+            'kwargs':{},
+            },
+        'flatbroadmom0':
+            {
+            'algorithm':'mom0',
+            'mask':'_flatbroadmask.fits',
+            'ext':'_flatbroad_mom0.fits',
+            'ext_error':'_flatbroad_emom0.fits',
+            'kwargs':{},
+            },
+        }
+
+    # native resolution
+    this_base_infile = working_dir+infile
+    this_infile = this_base_infile
+    print("Flat maps for ", this_infile)
+
+    for this_mom_key in mom_list:      
+        this_mom = mom_list[this_mom_key]
+        this_mask_file = this_infile.replace('.fits',this_mom['mask'])
+        this_noise_file = this_infile.replace('.fits','_noise.fits')
+        this_out_file = this_infile.replace('.fits',this_mom['ext'])
+        this_error_file = this_infile.replace('.fits',this_mom['ext_error'])
+        sco.moment_generator(
+            this_infile,
+            mask=this_mask_file, noise=this_noise_file,
+            moment=this_mom['algorithm'], momkwargs=this_mom['kwargs'],
+            outfile=this_out_file, errorfile=this_error_file,
+            channel_correlation=None,
+        )
+
+    # angular resolutions
+    for this_ext in target_angular:
+        this_infile = this_base_infile.replace('.fits','_'+this_ext+'.fits')
+        for this_mom_key in mom_list:      
+            this_mom = mom_list[this_mom_key]
+            this_mask_file = this_infile.replace('.fits',this_mom['mask'])
+            this_noise_file = this_infile.replace('.fits','_noise.fits')
+            this_out_file = this_infile.replace('.fits',this_mom['ext'])
+            this_error_file = this_infile.replace('.fits',this_mom['ext_error'])
+            sco.moment_generator(
+                this_infile,
+                mask=this_mask_file, noise=this_noise_file,
+                moment=this_mom['algorithm'], momkwargs=this_mom['kwargs'],
+                outfile=this_out_file, errorfile=this_error_file,
+                channel_correlation=None,
+            )
+
+    # physical resolutions
+    for this_ext in target_physical:
+        this_infile = this_base_infile.replace('.fits','_'+this_ext+'.fits')
+        for this_mom_key in mom_list:      
+            this_mom = mom_list[this_mom_key]
+            this_mask_file = this_infile.replace('.fits',this_mom['mask'])
+            this_noise_file = this_infile.replace('.fits','_noise.fits')
+            this_out_file = this_infile.replace('.fits',this_mom['ext'])
+            this_error_file = this_infile.replace('.fits',this_mom['ext_error'])
+            sco.moment_generator(
+                this_infile,
+                mask=this_mask_file, noise=this_noise_file,
+                moment=this_mom['algorithm'], momkwargs=this_mom['kwargs'],
+                outfile=this_out_file, errorfile=this_error_file,
+                channel_correlation=None,
+            )
+            
+# endregion

--- a/phangs-alma_keys/derived_key.txt
+++ b/phangs-alma_keys/derived_key.txt
@@ -38,11 +38,16 @@
 
 # convolve_kw - keywords for convolution.
 
+# shuffle_kw - keywords for velocity shuffling.
+
 # noise_kw - keywords for noise estimation.
 
 # strictmask_kw - keywords for generation of stict masks.
 
 # broadmask_kw - keywords for generation of broad masks.
+
+# flatstrictmask_kw - keywords for generation of flat stict masks.
+# flatbroadmask_kw - keywords for generation of flat broad masks.
 
 # mask_configs - the names of other configurations to link when
 # creating broad masks. All masks for all linked configurations will
@@ -57,6 +62,8 @@ all		all	convolve_kw	{}
 
 all		all	noise_kw	{'spec_box':5,'iterations':3}
 
+all	    all	shuffle_kw	{}
+
 12m+7m+tp	all	strictmask_kw	{'hi_thresh':4.0,'hi_nchan':2,'lo_thresh':2.0,'lo_nchan':2}
 12m+7m+tp	all	strictmask_kw	{'grow_xy':0,'grow_v':0}
 12m+7m+tp	all	strictmask_kw	{'min_pix':None,'min_area':None}
@@ -70,6 +77,9 @@ all		all	strictmask_kw	{'grow_xy':0,'grow_v':0}
 all		all	strictmask_kw	{'min_pix':None,'min_area':None}
 
 all		all	broadmask_kw	{}
+
+#all		all	flatstrictmask_kw	{'window':'50km/s'}
+#all		all	flatbroadmask_kw	{'window':'50km/s'}
 
 12m		co21	phys_res	{'60pc':60.0,'90pc':90.0,'120pc':120.0,'150pc':150.0}
 12m		co21	ang_res		{'2as':2.0}
@@ -87,6 +97,7 @@ all		all	broadmask_kw	{}
 12m+7m		co21	moments		['strictmom0','strictmom1','strictmom2','strictew']
 12m+7m		co21	moments		['broadmom0','broadtpeak','broadtpeak12p5','broadmom1']
 12m+7m		co21	moments		['mom1wprior']
+12m+7m		co21	moments		['flatstrictmom0','flatbroadmom0']
 12m+7m		c18o21	moments		['strictmom0','broadmom0']
 
 12m+7m+tp	co21	phys_res	{'60pc':60.0,'90pc':90.0,'120pc':120.0,'150pc':150.0,'500pc':500.0,'750pc':750.0,'1kpc':1000.0}
@@ -96,6 +107,7 @@ all		all	broadmask_kw	{}
 12m+7m+tp	co21	moments		['strictmom0','strictmom1','strictmom2','strictew']
 12m+7m+tp	co21	moments		['broadmom0','broadtpeak','broadtpeak12p5','broadmom1']
 12m+7m+tp	co21	moments		['mom1wprior']
+12m+7m+tp	co21	moments		['flatstrictmom0','flatbroadmom0']
 12m+7m+tp	c18o21	moments		['strictmom0','broadmom0']
 
 7m		co21	phys_res	{'60pc':60.0,'90pc':90.0,'120pc':120.0,'150pc':150.0,'500pc':500.0,'750pc':750.0,'1kpc':1000.0}
@@ -106,6 +118,7 @@ all		all	broadmask_kw	{}
 7m		co21	moments		['strictmom0','strictmom1','strictmom2','strictew']
 7m		co21	moments		['broadmom0','broadtpeak','broadtpeak12p5','broadmom1']
 7m		co21	moments		['mom1wprior']
+7m	    co21	moments		['flatstrictmom0','flatbroadmom0']
 7m		c18o21	moments		['strictmom0','broadmom0']
 
 7m+tp		co21	phys_res	{'60pc':60.0,'90pc':90.0,'120pc':120.0,'150pc':150.0,'500pc':500.0,'750pc':750.0,'1kpc':1000.0}
@@ -114,6 +127,7 @@ all		all	broadmask_kw	{}
 7m+tp		co21	moments		['strictmom0','strictmom1','strictmom2','strictew']
 7m+tp		co21	moments		['broadmom0','broadtpeak','broadtpeak12p5','broadmom1']
 7m+tp		co21	moments		['mom1wprior']
+7m+tp	    co21	moments		['flatstrictmom0','flatbroadmom0']
 7m+tp		c18o21	moments		['strictmom0','broadmom0']
 
 

--- a/phangs-alma_keys/master_key.txt
+++ b/phangs-alma_keys/master_key.txt
@@ -71,6 +71,14 @@
 # moment maps and masks from the postprocessed image cubes. Each
 # individual target will have a subdirectory of this parent derived
 # directory where processing for that target occurs.
+
+# 'vfield_root' 
+
+# is the root directory for velocity fields used for the shuffled
+# products. Each individual target will have a subdirectory of this 
+# parent derived directory where processing for that target occurs.
+# The velocity field can either be provided or created from the
+# moment-1 in the derived products stage.
  
 # ------------------------------------------------------------------------
 
@@ -168,19 +176,20 @@
 
 # Locations
 
-key_dir        	     	/data/tycho/0/leroy.42/reduction/alma/phangs_pipeline_configs/phangs-alma/phangs-alma_keys/
+key_dir        	    /data/tycho/0/leroy.42/reduction/alma/phangs_pipeline_configs/phangs-alma/phangs-alma_keys/
 cleanmask_root		/data/tycho/0/leroy.42/reduction/alma/phangs-alma/cleanmasks/
 imaging_root		/data/tycho/0/leroy.42/reduction/alma/phangs-alma/imaging/
 postprocess_root	/data/tycho/0/leroy.42/reduction/alma/phangs-alma/postprocess/
 derived_root		/data/tycho/0/leroy.42/reduction/alma/phangs-alma/derived/
 release_root		/data/tycho/0/leroy.42/reduction/alma/phangs-alma/release/
-ms_root			/data/tycho/0/leroy.42/reduction/alma/phangs-alma/uvdata/
-ms_root			/data/young/leroy.42/alma_data/PHANGS/
+ms_root			    /data/tycho/0/leroy.42/reduction/alma/phangs-alma/uvdata/
+ms_root			    /data/young/leroy.42/alma_data/PHANGS/
 singledish_root		/data/tycho/0/leroy.42/reduction/alma/phangs-alma/singledish/
+vfield_root		    /data/tycho/0/leroy.42/reduction/alma/phangs-alma/vfield/
 
 # Data files
 
-ms_key			ms_file_key.txt
+ms_key			    ms_file_key.txt
 singledish_key		singledish_key.txt
 cleanmask_key		cleanmask_key.txt
 distance_key		distance_key.txt
@@ -193,5 +202,5 @@ moment_key		moment_key.txt
 derived_key		derived_key.txt
 imaging_key		imaging_recipes.txt
 linmos_key		linearmosaic_definitions.txt
-override_key		overrides.txt
+override_key    overrides.txt
 dir_key			dir_key.txt

--- a/phangs-alma_keys/moment_key.txt
+++ b/phangs-alma_keys/moment_key.txt
@@ -131,3 +131,21 @@ mom1wprior 	ext_error 	_emom1wprior
 mom1wprior	maps_to_pass	['strict_mom1','strict_emom1','broad_mom1','broad_emom1','broad_mom0','broad_emom0']
 mom1wprior 	other_exts 	{'vfield_prior':'_7m+tp_co21_15as_strict_mom1.fits'}
 mom1wprior	kwargs 		{'vfield_reject_thresh':'20km/s','mom0_thresh':2.0}
+
+##########################################################################
+# FLAT MAPS - THESE CAN DEPEND ON OTHER MAPS AS INPUT
+##########################################################################
+
+flatstrictmom0	algorithm	mom0
+flatstrictmom0	mask		flatstrictmask
+flatstrictmom0	ext		    _flatstrict_mom0
+flatstrictmom0	ext_error	_flatstrict_emom0
+flatstrictmom0	round		3
+flatstrictmom0	kwargs		{}
+
+flatbroadmom0	algorithm	mom0
+flatbroadmom0	mask		flatbroadmask
+flatbroadmom0	ext		    _flatbroad_mom0
+flatbroadmom0	ext_error	_flatbroad_emom0
+flatbroadmom0	round		3
+flatbroadmom0	kwargs		{}

--- a/phangs-alma_keys/window_key.txt
+++ b/phangs-alma_keys/window_key.txt
@@ -1,0 +1,115 @@
+##########################################################################
+# VELOCITY WINDOW KEY
+##########################################################################
+
+# Key to map from target name to velocity window in km/s
+
+# N.B. this file is automatically produced in some cases and this
+# documentation would be overwritten.
+
+# When the user requests to construct the flat masks used to produce the 
+# flat moment-0 maps the velocity window is needed. This file provides that 
+# velocity window.
+
+# Column 1: target name
+# Column 2: velocity window in km/s
+
+##########################################################################
+
+# %ECSV 1.0
+# ---
+# datatype:
+# - {name: target, datatype: string}
+# - {name: window, unit: km / s, datatype: float64}
+# delimiter: ','
+# schema: astropy-2.0
+target,window
+circinus,70.0
+ic1954,30.0
+ic5273,30.0
+ic5332,20.0
+ngc0247,30.0
+ngc0253,40.0
+ngc0300,20.0
+ngc0628,40.0
+ngc0685,40.0
+ngc1068,40.0
+ngc1087,40.0
+ngc1097,60.0
+ngc1300,30.0
+ngc1317,50.0
+ngc1365,200.0
+ngc1385,60.0
+ngc1433,30.0
+ngc1511,80.0
+ngc1512,30.0
+ngc1546,60.0
+ngc1559,60.0
+ngc1566,40.0
+ngc1637,30.0
+ngc1672,40.0
+ngc1792,60.0
+ngc1809,40.0
+ngc2090,40.0
+ngc2283,40.0
+ngc2566,40.0
+ngc2775,30.0
+ngc2835,30.0
+ngc2903,50.0
+ngc2997,50.0
+ngc3059,40.0
+ngc3137,40.0
+ngc3239,30.0
+ngc3351,30.0
+ngc3489,60.0
+ngc3507,40.0
+ngc3511,40.0
+ngc3521,60.0
+ngc3596,40.0
+ngc3599,30.0
+ngc3621,60.0
+ngc3626,40.0
+ngc3627,60.0
+ngc4207,50.0
+ngc4254,60.0
+ngc4293,60.0
+ngc4298,50.0
+ngc4303,60.0
+ngc4321,50.0
+ngc4424,50.0
+ngc4457,60.0
+ngc4459,60.0
+ngc4476,50.0
+ngc4477,40.0
+ngc4496a,40.0
+ngc4535,50.0
+ngc4536,40.0
+ngc4540,50.0
+ngc4548,40.0
+ngc4569,40.0
+ngc4571,30.0
+ngc4579,50.0
+ngc4596,50.0
+ngc4654,50.0
+ngc4689,40.0
+ngc4694,40.0
+ngc4731,50.0
+ngc4781,50.0
+ngc4826,50.0
+ngc4941,30.0
+ngc4945,80.0
+ngc4951,40.0
+ngc5042,40.0
+ngc5068,30.0
+ngc5128,50.0
+ngc5134,50.0
+ngc5236,50.0
+ngc5248,50.0
+ngc5530,40.0
+ngc5643,50.0
+ngc6300,50.0
+ngc6744,20.0
+ngc7456,30.0
+ngc7496,30.0
+ngc7743,50.0
+ngc7793,30.0

--- a/phangsPipeline/handlerDerived.py
+++ b/phangsPipeline/handlerDerived.py
@@ -62,7 +62,8 @@ if has_astropy_speccube:
 
     from .scConvolution import smooth_cube
     from .scNoiseRoutines import recipe_phangs_noise
-    from .scMaskingRoutines import recipe_phangs_strict_mask, recipe_phangs_broad_mask
+    from .scMaskingRoutines import recipe_phangs_strict_mask, recipe_phangs_broad_mask, recipe_phangs_flat_mask
+    from .scStackingRoutines import recipe_phangs_vfield, recipe_shuffle_cube
 
     #from . import scDerivativeRoutines as scderiv
     from .scMoments import moment_generator
@@ -102,6 +103,10 @@ if has_astropy_speccube:
                 do_broadmask=False,
                 do_moments=False,
                 do_secondary=False,
+                do_vfield=False,
+                do_shuffling=False, 
+                do_flatmask=False,
+                do_flatmaps=False,
                 make_directories=True,
                 extra_ext_in='',
                 extra_ext_out='',
@@ -121,6 +126,10 @@ if has_astropy_speccube:
                 do_broadmask = True
                 do_moments = True
                 do_secondary = True
+                do_vfield=True,
+                do_shuffling = True
+                do_flatmask = True
+                do_flatmaps = True
 
             # Error checking
 
@@ -308,7 +317,145 @@ if has_astropy_speccube:
                             target=this_target, product=this_product, config=this_config,
                             res_tag=this_res, overwrite=overwrite)
 
+            # Create velocity field.
 
+            if do_vfield:
+    
+                for this_target, this_product, this_config in \
+                        self.looper(do_targets=True,do_products=True,do_configs=True):
+
+                    # Only build one velocity field that covers all resolutions
+
+                    self.task_build_vfield(
+                        target=this_target, config=this_config, product=this_product,
+                        overwrite=overwrite, res_tag=None)
+
+
+            # Make shuffled cube.
+
+            if do_shuffling:
+
+                for this_target, this_product, this_config in \
+                        self.looper(do_targets=True,do_products=True,do_configs=True):
+
+                    # Always start with the native resolution
+
+                    self.task_shuffle_cube(
+                        target=this_target, config=this_config, product=this_product,
+                        overwrite=overwrite)
+
+                    # Loop over all angular and physical resolutions.
+                    # N.B. we only want native resolution shuffled cubes;
+                    # feel free to uncomment the lines below for other resolutions
+
+                    # res_dict = self._kh.get_ang_res_dict(
+                    #     config=this_config,product=this_product)
+                    # res_list = list(res_dict)
+                    # if len(res_list) > 0:
+                    #     res_list.sort()
+                    # for this_res_tag in res_list:
+
+                    #     self.task_shuffle_cube(
+                    #         target=this_target, config=this_config, product=this_product,
+                    #         res_tag=this_res_tag, overwrite=overwrite)
+
+                    # res_dict = self._kh.get_phys_res_dict(
+                    #     config=this_config,product=this_product)
+                    # res_list = list(res_dict)
+                    # if len(res_list) > 0:
+                    #     res_list.sort()
+                    # for this_res_tag in res_list:
+
+                    #     self.task_shuffle_cube(
+                    #         target=this_target, config=this_config, product=this_product,
+                    #         res_tag=this_res_tag, overwrite=overwrite)
+
+            # Make "flat masks" for each cube
+
+            if do_flatmask:
+
+                for this_target, this_product, this_config in \
+                        self.looper(do_targets=True,do_products=True,do_configs=True):
+
+                    #
+                    # Flat Strict Mask
+
+                    # Always start with the native resolution
+
+                    self.task_build_flat_strict_mask(
+                        target=this_target, config=this_config, product=this_product,
+                        overwrite=overwrite, res_tag=None)
+
+                    # Loop over all angular and physical resolutions.
+
+                    for this_res in self._kh.get_ang_res_dict(
+                        config=this_config,product=this_product):
+
+                        self.task_build_flat_strict_mask(
+                            target=this_target, config=this_config, product=this_product,
+                            overwrite=overwrite, res_tag=this_res)
+
+                    for this_res in self._kh.get_phys_res_dict(
+                        config=this_config,product=this_product):
+
+                        self.task_build_flat_strict_mask(
+                            target=this_target, config=this_config, product=this_product,
+                            overwrite=overwrite, res_tag=this_res)
+                                          
+                    #
+                    # Flat Broad Mask
+
+                    # Always start with the native resolution
+
+                    self.task_build_flat_broad_mask(
+                        target=this_target, config=this_config, product=this_product,
+                        overwrite=overwrite, res_tag=None)
+
+                    # Loop over all angular and physical resolutions.
+
+                    for this_res in self._kh.get_ang_res_dict(
+                        config=this_config,product=this_product):
+
+                        self.task_build_flat_broad_mask(
+                            target=this_target, config=this_config, product=this_product,
+                            overwrite=overwrite, res_tag=this_res)
+
+                    for this_res in self._kh.get_phys_res_dict(
+                        config=this_config,product=this_product):
+
+                        self.task_build_flat_broad_mask(
+                            target=this_target, config=this_config, product=this_product,
+                            overwrite=overwrite, res_tag=this_res)
+
+            # Make "flat maps" - derived data products.
+
+            if do_flatmaps:
+
+                for this_target, this_product, this_config in \
+                        self.looper(do_targets=True,do_products=True,do_configs=True):
+
+                    # Always start with the native resolution
+
+                    self.task_generate_flatmaps(
+                        target=this_target, product=this_product, config=this_config,
+                        res_tag=None, overwrite=overwrite)
+
+                    # Loop over all angular and physical resolutions.
+
+                    for this_res in self._kh.get_ang_res_dict(
+                        config=this_config,product=this_product):
+
+                        self.task_generate_flatmaps(
+                            target=this_target, product=this_product, config=this_config,
+                            res_tag=this_res, overwrite=overwrite)
+
+                    for this_res in self._kh.get_phys_res_dict(
+                        config=this_config,product=this_product):
+
+                        self.task_generate_flatmaps(
+                            target=this_target, product=this_product, config=this_config,
+                            res_tag=this_res, overwrite=overwrite)
+                        
     # end of loop
 
 
@@ -389,6 +536,24 @@ if has_astropy_speccube:
             fname_dict['coverage2d'] = coverage2d_filename
 
             # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+            # Velocity field
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+            vfield_filename = target+'_vfield.fits'
+            fname_dict['vfield'] = vfield_filename
+
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+            # Shuffled Cubes
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+            shuffled_filename = utilsFilenames.get_cube_filename(
+                target = target, config = config, product = product,
+                ext = res_tag+extra_ext_out+'_shuffled',
+                casa = False)
+
+            fname_dict['shuffled'] = shuffled_filename
+
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
             # Noise Cubes
             # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
 
@@ -426,6 +591,28 @@ if has_astropy_speccube:
             fname_dict['broadmask'] = broadmask_filename
 
             # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+            # Flat Strict Mask
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+            flatstrictmask_filename = utilsFilenames.get_cube_filename(
+                target = target, config = config, product = product,
+                ext = extra_ext_out+'_flatstrictmask',
+                casa = False)
+
+            fname_dict['flatstrictmask'] = flatstrictmask_filename
+
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+            # Flat Broad Mask
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+            flatbroadmask_filename = utilsFilenames.get_cube_filename(
+                target = target, config = config, product = product,
+                ext = extra_ext_out+'_flatbroadmask',
+                casa = False)
+
+            fname_dict['flatbroadmask'] = flatbroadmask_filename
+
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
             # Moments
             # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
 
@@ -447,6 +634,8 @@ if has_astropy_speccube:
         ##################################################################
         # Tasks - discrete steps on target, product, config combinations #
         ##################################################################
+
+        # region convolve
 
         def task_convolve(
             self,
@@ -537,10 +726,10 @@ if has_astropy_speccube:
             logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&")
             logger.info("")
 
-            logger.info("Input file "+input_file)
+            logger.info("Input file: "+input_file)
             logger.info("Target file: "+outfile)
             logger.info("Coverage file: "+coveragefile)
-            logger.info("Keywords: "+str(convolve_kwargs))
+            logger.info("Keyword arguments: "+str(convolve_kwargs))
 
             if (not self._dry_run):
 
@@ -565,7 +754,7 @@ if has_astropy_speccube:
 
                     if res_type == 'ang':
                         input_res_value = res_value*u.arcsec
-                        smooth_cube(incube=indir+input_file, outfile=outdir+outfile,
+                        smooth_cube(cube_in=indir+input_file, outfile=outdir+outfile,
                                     angular_resolution=input_res_value,
                                     tol=tol, nan_treatment=nan_treatment,
                                     make_coverage_cube=True, coveragefile=outdir+coveragefile,
@@ -579,7 +768,7 @@ if has_astropy_speccube:
                             return()
                         this_distance = this_distance*1e6*u.pc
                         input_res_value = res_value*u.pc
-                        smooth_cube(incube=indir+input_file, outfile=outdir+outfile,
+                        smooth_cube(cube_in=indir+input_file, outfile=outdir+outfile,
                                     linear_resolution=input_res_value, distance=this_distance,
                                     tol=tol, nan_treatment=nan_treatment,
                                     make_coverage_cube=True, coveragefile=outdir+coveragefile,
@@ -587,6 +776,9 @@ if has_astropy_speccube:
                                     overwrite=overwrite)
 
             return()
+        # endregion
+
+        # region noise
 
         def task_estimate_noise(
             self,
@@ -636,7 +828,7 @@ if has_astropy_speccube:
             logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&")
             logger.info("")
 
-            logger.info("Input file "+input_file)
+            logger.info("Input file: "+input_file)
             logger.info("Target file: "+outfile)
             logger.info("Keyword arguments: "+str(noise_kwargs))
 
@@ -645,11 +837,14 @@ if has_astropy_speccube:
             if (not self._dry_run):
 
                 recipe_phangs_noise(
-                    incube=indir+input_file,
+                    cube_in=indir+input_file,
                     outfile=outdir+outfile,
                     noise_kwargs=noise_kwargs,
                     return_spectral_cube=False,
                     overwrite=overwrite)
+        # endregion
+
+        # region strict mask
 
         def task_build_strict_mask(
             self,
@@ -697,7 +892,7 @@ if has_astropy_speccube:
 
             if not (os.path.isfile(indir+coverage_file)):
                 logger.warning("Missing coverage estimate: "+indir+coverage_file)
-                logger.warning("This may be fine. Proceeding")
+                logger.warning("This may be fine. Proceeding.")
                 coverage_file = None
 
             # Access keywords for mask generation
@@ -717,12 +912,12 @@ if has_astropy_speccube:
             logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&")
             logger.info("")
 
-            logger.info("Input file "+input_file)
-            logger.info("Noise file "+noise_file)
+            logger.info("Input file: "+input_file)
+            logger.info("Noise file: "+noise_file)
             if coverage_file is not None:
-                logger.info("Coverage file "+coverage_file)
+                logger.info("Coverage file: "+coverage_file)
             logger.info("Target file: "+outfile)
-            logger.info("Kwargs: "+str(strictmask_kwargs))
+            logger.info("Keyword arguments: "+str(strictmask_kwargs))
 
             # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
             # Call the masking routines
@@ -738,13 +933,16 @@ if has_astropy_speccube:
                     coverage_file_in = None
 
                 recipe_phangs_strict_mask(
-                    incube=indir+input_file,
+                    cube_in=indir+input_file,
                     innoise=indir+noise_file,
                     coverage=coverage_file_in,
                     outfile=outdir+outfile,
                     mask_kwargs=strictmask_kwargs,
                     return_spectral_cube=False,
                     overwrite=overwrite)
+        # endregion
+
+        # region broad mask
 
         def task_build_broad_mask(
             self,
@@ -846,10 +1044,10 @@ if has_astropy_speccube:
             logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&")
             logger.info("")
 
-            logger.info("Input file "+input_file)
+            logger.info("Input file: "+input_file)
             logger.info("List of other masks "+str(list_of_masks))
             logger.info("Target file: "+outfile)
-            logger.info("Kwargs: "+str(broadmask_kwargs))
+            logger.info("Keyword arguments: "+str(broadmask_kwargs))
 
             # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
             # Call the mask combining routine
@@ -864,7 +1062,10 @@ if has_astropy_speccube:
                     #mask_kwargs=broadmask_kwargs,
                     #return_spectral_cube=False,
                     overwrite=overwrite)
+        # endregion
 
+        # region moments
+        
         def task_generate_moments(
             self,
             target = None,
@@ -1021,8 +1222,9 @@ if has_astropy_speccube:
                         moment=mom_params['algorithm'], momkwargs=mom_params['kwargs'],
                         outfile=outfile, errorfile=errorfile,
                         channel_correlation=None)
+        # endregion
 
-
+        # region secondary moments
 
         def task_generate_secondary_moments(
             self,
@@ -1129,7 +1331,7 @@ if has_astropy_speccube:
 
             logger.info("... Total stages of moment calculation: {0}".format(len(uniqrounds)))
 
-            for thisround in uniqrounds[1:]:
+            for thisround in uniqrounds[1:2]:
                 logger.info("... Now, calculate all moments in stage {0}".format(thisround))
                 logger.info("")
 
@@ -1230,7 +1432,7 @@ if has_astropy_speccube:
                         # Call the moment generator
                         # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-                        print(kwargs_dict)
+                        # print(kwargs_dict)
 
                         moment_generator(
                             indir+input_file, mask=mask_file, noise=noise_in,
@@ -1240,6 +1442,638 @@ if has_astropy_speccube:
                             momkwargs=kwargs_dict,
                             # Deprecated context
                             )
+        # endregion
+                        
+        # region vfield
+        def task_build_vfield(
+            self,
+            target = None,
+            config = None,
+            product = None,
+            res_tag = None,
+            extra_ext = '',
+            overwrite = False,
+            ):
+            """
+            Generate a combined velocity field from a list of mom1 maps.
+            """
+
+            # Generate file names
+
+            indir = self._kh.get_derived_dir_for_target(target=target, changeto=False)
+            indir = os.path.abspath(indir)+'/'
+
+            outdir = self._kh.get_vfield_dir_for_target(target=target, changeto=False)
+            outdir = os.path.abspath(outdir)+'/'
+
+            fname_dict = self._fname_dict(
+                target=target, config=config, product=product, res_tag=res_tag,
+                extra_ext_in=extra_ext)
+
+            input_file = fname_dict['momentroot']+'_mom1wprior.fits'
+            outfile = fname_dict['vfield']
+
+            # Check input file existence
+
+            if not (os.path.isfile(indir+input_file)):
+                logger.warning("Missing cube: "+indir+input_file)
+                return()
+
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+            # Create the list of maps to combine
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+            list_of_vfiels = []
+
+            linked_configs = self._kh.get_linked_mask_configs(
+                config=config, product=product)
+
+            if config not in linked_configs:
+                linked_configs.append(config)
+
+            for cross_config in linked_configs:
+
+                fname_dict = self._fname_dict(
+                    target=target, config=cross_config, product=product, res_tag=None,
+                    extra_ext_in=extra_ext)
+
+                this_vfield = fname_dict['momentroot']+'_mom1wprior.fits'
+                if this_vfield not in list_of_vfiels:
+                    if os.path.isfile(indir+this_vfield):
+                        list_of_vfiels.append(indir+this_vfield)
+
+                # Loop over all angular and physical resolutions.
+
+                for this_res in self._kh.get_ang_res_dict(
+                    config=cross_config,product=product):
+
+                    fname_dict = self._fname_dict(
+                        target=target, config=cross_config, product=product, res_tag=this_res,
+                        extra_ext_in=extra_ext)
+
+                    this_vfield = fname_dict['momentroot']+'_mom1wprior.fits'
+                    if this_vfield not in list_of_vfiels:
+                        if os.path.isfile(indir+this_vfield):
+                            list_of_vfiels.append(indir+this_vfield)
+
+                for this_res in self._kh.get_phys_res_dict(
+                    config=cross_config,product=product):
+
+                    fname_dict = self._fname_dict(
+                        target=target, config=cross_config, product=product, res_tag=this_res,
+                        extra_ext_in=extra_ext)
+
+                    this_vfield = fname_dict['momentroot']+'_mom1wprior.fits'
+                    if this_vfield not in list_of_vfiels:
+                        if os.path.isfile(indir+this_vfield):
+                            list_of_vfiels.append(indir+this_vfield)
+
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+            # Report
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+            logger.info("")
+            logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&")
+            logger.info("Creating a velocity field for:")
+            logger.info(str(target)+" , "+str(product)+" , "+str(config))
+            logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&")
+            logger.info("")
+
+            logger.info("Input file: "+input_file)
+            logger.info("List of other velocity fields:")
+            for this_vfield in list_of_vfiels:
+                logger.info(str(this_vfield))
+            logger.info("Target file: "+outfile)
+
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+            # Call the vfield combining routine
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+            if (not self._dry_run):
+                recipe_phangs_vfield(
+                    indir+input_file,
+                    list_of_vfields=list_of_vfiels,
+                    outfile=outdir+outfile,
+                    overwrite=overwrite)
+        # endregion
+
+        # region shuffle cube
+
+        def task_shuffle_cube(
+            self,
+            target = None,
+            config = None,
+            product = None,
+            res_tag = None,
+            extra_ext = '',
+            overwrite = False,
+            ):
+            """
+            Construct shuffled cube and save it to disk.
+            """
+
+            # Generate file names
+
+            indir = self._kh.get_derived_dir_for_target(target=target, changeto=False)
+            indir = os.path.abspath(indir)+'/'
+
+            outdir = self._kh.get_derived_dir_for_target(target=target, changeto=False)
+            outdir = os.path.abspath(outdir)+'/'
+
+            vfield_dir = self._kh.get_vfield_dir_for_target(target=target, changeto=False)
+            vfield_dir = os.path.abspath(vfield_dir)+'/'
+
+            fname_dict = self._fname_dict(
+                target=target, config=config, product=product, res_tag=res_tag,
+                extra_ext_in=extra_ext)
+
+            input_file = fname_dict['cube']
+            vfield_file = fname_dict['vfield']
+            outfile = fname_dict['shuffled']
+
+            # Check input file existence
+
+            if not (os.path.isfile(indir+input_file)):
+                logger.warning("Missing cube: "+indir+input_file)
+                return()
+
+            if not (os.path.isfile(vfield_dir+vfield_file)):
+                logger.warning("Missing velocity field: "+vfield_dir+vfield_file)
+                return()
+
+            # Access keywords for noise generation
+
+            shuffle_kwargs = self._kh.get_derived_kwargs(
+                config=config, product=product, kwarg_type='shuffle_kw')
+
+            # Report
+
+            logger.info("")
+            logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&")
+            logger.info("Running shuffling for:")
+            logger.info(str(target)+" , "+str(product)+" , "+str(config))
+            logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&")
+            logger.info("")
+
+            logger.info("Input file: "+input_file)
+            logger.info("Target file: "+outfile)
+            logger.info("Keyword arguments: "+str(shuffle_kwargs))
+
+            # Call shuffling routine
+
+            recipe_shuffle_cube(
+                cube_in=indir+input_file,
+                vfield_in=vfield_dir+vfield_file,
+                outfile=outdir+outfile,
+                overwrite=overwrite)
+        # endregion
+
+        # region flat strict mask
+
+        def task_build_flat_strict_mask(
+            self,
+            target = None,
+            config = None,
+            product = None,
+            res_tag = None,
+            extra_ext = '',
+            overwrite = False,
+            ):
+            """
+            Construct the flat strict mask and save it to disk.
+            """
+
+            # Generate file names
+
+            indir = self._kh.get_derived_dir_for_target(target=target, changeto=False)
+            indir = os.path.abspath(indir)+'/'
+
+            outdir = self._kh.get_derived_dir_for_target(target=target, changeto=False)
+            outdir = os.path.abspath(outdir)+'/'
+
+            vfield_dir = self._kh.get_vfield_dir_for_target(target=target, changeto=False)
+            vfield_dir = os.path.abspath(vfield_dir)+'/'
+
+            fname_dict = self._fname_dict(
+                target=target, config=config, product=product, res_tag=res_tag,
+                extra_ext_in=extra_ext)
+
+            input_file = fname_dict['cube']
+            vfield_file = fname_dict['vfield']
+            mask_file = fname_dict['strictmask']
+            coverage_file = fname_dict['coverage']
+            coverage2d_file = fname_dict['coverage2d']
+
+            outfile = fname_dict['flatstrictmask']
+
+            # Check input file existence
+
+            if not (os.path.isfile(indir+input_file)):
+                logger.warning("Missing cube: "+indir+input_file)
+                return()
+
+            if not (os.path.isfile(vfield_dir+vfield_file)):
+                logger.warning("Missing velocity field: "+vfield_dir+vfield_file)
+                return()
+
+            if not (os.path.isfile(indir+mask_file)):
+                logger.warning("Missing strict mask: "+indir+mask_file)
+                return()
+
+            # Coverage
+
+            if not (os.path.isfile(indir+coverage_file)):
+                logger.warning("Missing coverage estimate: "+indir+coverage_file)
+                logger.warning("This may be fine. .")
+                coverage_file = None
+
+            # Access keywords for mask generation
+
+            flatmask_kwargs = self._kh.get_derived_kwargs(
+                config=config, product=product, kwarg_type='flatstrictmask_kw')
+
+            # get velocity window from separate key if not provided from derived key
+            if not flatmask_kwargs:
+                this_window = self._kh.get_window_for_target(target)
+                if this_window is None:
+                    logger.error("No velocity window for target "+target)
+                    return()
+                flatmask_kwargs = {'v_window':this_window}
+
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+            # Report
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+            logger.info("")
+            logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&")
+            logger.info("Creating a flat strict mask for:")
+            logger.info(str(target)+" , "+str(product)+" , "+str(config))
+            logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&")
+            logger.info("")
+
+            logger.info("Input file: "+input_file)
+            logger.info("Velocity field file: "+vfield_file)
+            logger.info("Strict mask file: "+mask_file)
+            if coverage_file is not None:
+                logger.info("Coverage file: "+coverage_file)
+            logger.info("Target file: "+outfile)
+            logger.info("Keyword arguments: "+str(flatmask_kwargs))
+
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+            # Call the masking routines
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+            if (not self._dry_run):
+
+                # ... put the directory into the name to allow it to remain
+                # None when missing.
+                if coverage_file is not None:
+                    coverage_file_in = indir+coverage_file
+                else:
+                    coverage_file_in = None
+
+                # run flat mask routine
+                recipe_phangs_flat_mask(
+                    cube_in=indir+input_file,
+                    vfield_in=vfield_dir+vfield_file,
+                    mask_in=indir+mask_file,
+                    coverage=coverage_file_in,
+                    outfile=outdir+outfile,
+                    mask_kwargs=flatmask_kwargs,
+                    return_spectral_cube=False,
+                    overwrite=overwrite)
+
+        # region flat broad mask
+
+        def task_build_flat_broad_mask(
+            self,
+            target = None,
+            config = None,
+            product = None,
+            res_tag = None,
+            extra_ext = '',
+            overwrite = False,
+            ):
+            """
+            Construct the flat broad mask and save it to disk.
+            """
+
+            # Generate file names
+
+            indir = self._kh.get_derived_dir_for_target(target=target, changeto=False)
+            indir = os.path.abspath(indir)+'/'
+
+            outdir = self._kh.get_derived_dir_for_target(target=target, changeto=False)
+            outdir = os.path.abspath(outdir)+'/'
+
+            vfield_dir = self._kh.get_vfield_dir_for_target(target=target, changeto=False)
+            vfield_dir = os.path.abspath(vfield_dir)+'/'
+
+            fname_dict = self._fname_dict(
+                target=target, config=config, product=product, res_tag=res_tag,
+                extra_ext_in=extra_ext)
+
+            input_file = fname_dict['cube']
+            vfield_file = fname_dict['vfield']
+            mask_file = fname_dict['broadmask']
+            coverage_file = fname_dict['coverage']
+            coverage2d_file = fname_dict['coverage2d']
+
+            outfile = fname_dict['flatbroadmask']
+
+            # Check input file existence
+
+            if not (os.path.isfile(indir+input_file)):
+                logger.warning("Missing cube: "+indir+input_file)
+                return()
+
+            if not (os.path.isfile(vfield_dir+vfield_file)):
+                logger.warning("Missing velocity field: "+vfield_dir+vfield_file)
+                return()
+
+            if not (os.path.isfile(indir+mask_file)):
+                logger.warning("Missing broad mask: "+indir+mask_file)
+                return()
+
+            # Coverage
+
+            if not (os.path.isfile(indir+coverage_file)):
+                logger.warning("Missing coverage estimate: "+indir+coverage_file)
+                logger.warning("This may be fine. Proceeding.")
+                coverage_file = None
+
+            # Access keywords for mask generation
+            
+            flatmask_kwargs = self._kh.get_derived_kwargs(
+                config=config, product=product, kwarg_type='flatbroadmask_kw')
+            
+            # get velocity window from separate key if not provided from derived key
+            if not flatmask_kwargs:
+                this_window = self._kh.get_window_for_target(target)
+                if this_window is None:
+                    logger.error("No velocity window for target "+target)
+                    return()
+                flatmask_kwargs = {'window':this_window}
+
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+            # Report
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+            logger.info("")
+            logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&")
+            logger.info("Creating a flat broad mask for:")
+            logger.info(str(target)+" , "+str(product)+" , "+str(config))
+            logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&")
+            logger.info("")
+
+            logger.info("Input file: "+input_file)
+            logger.info("Velocity field file: "+vfield_file)
+            logger.info("Broad mask file: "+mask_file)
+            if coverage_file is not None:
+                logger.info("Coverage file: "+coverage_file)
+            logger.info("Target file: "+outfile)
+            logger.info("Keyword arguments: "+str(flatmask_kwargs))
+
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+            # Call the masking routines
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+            if (not self._dry_run):
+
+                # ... put the directory into the name to allow it to remain
+                # None when missing.
+                if coverage_file is not None:
+                    coverage_file_in = indir+coverage_file
+                else:
+                    coverage_file_in = None
+
+                # run flat mask routine
+                recipe_phangs_flat_mask(
+                    cube_in=indir+input_file,
+                    vfield_in=vfield_dir+vfield_file,
+                    mask_in=indir+mask_file,
+                    coverage=coverage_file_in,
+                    outfile=outdir+outfile,
+                    mask_kwargs=flatmask_kwargs,
+                    return_spectral_cube=False,
+                    overwrite=overwrite)
+        # end regions
+
+        # region flat maps
+
+        def task_generate_flatmaps(
+            self,
+            target = None,
+            config = None,
+            product = None,
+            res_tag = None,
+            extra_ext = '',
+            overwrite = False,
+            ):
+            """
+            Generate moment maps.
+            """
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+            # Look up filenames, list of moments, etc.
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+            # Generate file names
+
+            indir = self._kh.get_derived_dir_for_target(target=target, changeto=False)
+            indir = os.path.abspath(indir)+'/'
+
+            outdir = self._kh.get_derived_dir_for_target(target=target, changeto=False)
+            outdir = os.path.abspath(outdir)+'/'
+
+            # Filenames
+
+            fname_dict_nores = self._fname_dict(
+                target=target, config=config, product=product, res_tag=None,
+                extra_ext_in=extra_ext)
+
+            fname_dict = self._fname_dict(
+                target=target, config=config, product=product, res_tag=res_tag,
+                extra_ext_in=extra_ext)
+
+            # ... broad mask never has a resolution tag
+
+            broadmask_file = fname_dict_nores['flatbroadmask']
+
+            # ... files with resolution tag
+
+            input_file = fname_dict['cube']
+            noise_file = fname_dict['noise']
+            strictmask_file = fname_dict['flatstrictmask']
+
+            outroot = fname_dict['momentroot']
+
+            # Check input file and mask existence
+
+            if not (os.path.isfile(indir+input_file)):
+                logger.warning("Missing cube: "+indir+input_file)
+                return()
+
+            found_broadmask = (os.path.isfile(indir+broadmask_file))
+            found_strictmask = (os.path.isfile(indir+strictmask_file))
+
+            # Look up which moments to calculate
+
+            list_of_moments = self._kh.get_moment_list(config=config, product=product)
+
+            rounds = []
+            for this_mom in list_of_moments:
+                rounds.append(self._kh.get_params_for_moment(this_mom)['round'])
+            uniqrounds = sorted(list(set(rounds)))
+
+            if len(uniqrounds) == 1:
+                logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&")
+                logger.info("")
+                logger.info("... Total stages of moment calculation: {0}".format(len(uniqrounds)))
+                logger.info("... Secondary moments requested but not specified in moment keys")
+                logger.info("... Returning to main loop")
+                logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&")
+                logger.info("")
+                return()
+
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+            # Report
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+            logger.info("")
+            logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&")
+            logger.info("Generating moment maps for:")
+            logger.info(str(target)+" , "+str(product)+" , "+str(config))
+            if res_tag is not None:
+                logger.info("Resolution "+str(res_tag))
+            logger.info("Found a flat strict mask? "+str(found_strictmask))
+            logger.info("Found a flat broad mask? "+str(found_broadmask))
+            logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&")
+            logger.info("")
+
+            logger.info("... input file: "+input_file)
+            logger.info("... noise file: "+noise_file)
+            logger.info("... flat strict mask file: "+strictmask_file)
+            logger.info("... flat broad mask file: "+broadmask_file)
+            logger.info("... list of moments: "+str(list_of_moments))
+            logger.info("... output root: "+outroot)
+
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+            # Execute
+            # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+            logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&")
+            logger.info("")
+
+            logger.info("... Total stages of moment calculation: {0}".format(len(uniqrounds)))
+
+            for thisround in uniqrounds[2:3]:
+                logger.info("... Now, calculate all moments in stage {0}".format(thisround))
+                logger.info("")
+
+                sublist_of_moments = [this_mom for this_mom in list_of_moments
+                                    if self._kh.get_params_for_moment(this_mom)['round'] == thisround]
+
+                if (not self._dry_run):
+                    for this_mom in sublist_of_moments:
+                        logger.info('... generating moment: '+str(this_mom))
+
+                        proceed = True
+
+                        mom_params = self._kh.get_params_for_moment(this_mom)
+
+                        # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+                        # Look up mask
+                        # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+                        if mom_params['mask'] is None:
+                            mask_file = None
+                        elif mom_params['mask'].strip().lower() == 'none':
+                            mask_file = None
+                        elif mom_params['mask'] == 'flatstrictmask':
+                            if not found_strictmask:
+                                logger.warning("Flat strict mask needed but not found. Skipping.")
+                                continue
+                            mask_file = indir+strictmask_file
+                        elif mom_params['mask'] == 'flatbroadmask':
+                            if not found_broadmask:
+                                logger.warning("Flat broad mask needed but not found. Skipping.")
+                                continue
+                            mask_file = indir+broadmask_file
+                        else:
+                            logger.warning("Mask choice not recognized for moment: "+str(this_mom))
+                            logger.warning("Skipping.")
+                            continue
+
+                        # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+                        # Check noise
+                        # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+                        if not (os.path.isfile(indir+noise_file)):
+                            logger.warning("Missing noise: "+indir+noise_file)
+                            noise_in = None
+                            errorfile = None
+                        else:
+                            noise_in = indir+noise_file
+                            errorfile = outdir+outroot+mom_params['ext_error']+'.fits'
+
+                        # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+                        # Set up output file
+                        # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+                        outfile = outdir+outroot+mom_params['ext']+'.fits'
+
+                        # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+                        # Look up maps to pass and build the kwarg list
+                        # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+                        kwargs_dict = mom_params['kwargs']
+
+                        maps_to_pass = mom_params['maps_to_pass']
+                        for map_ext in maps_to_pass:
+
+                            # File name for this extension
+                            this_map_file = outroot+'_'+map_ext+'.fits'
+
+                            # Verify file existence
+                            if not (os.path.isfile(indir+this_map_file)):
+                                logger.warning("Missing needed context file: "+indir+this_map_file)
+                                proceed = False
+
+                            # Add as param to kwarg dict
+                            kwargs_dict[map_ext] = indir+this_map_file
+
+                        other_exts = mom_params['other_exts']
+                        for param_name in other_exts.keys():
+
+                            # File name for this extension
+                            this_ext = other_exts[param_name]
+
+                            # Code to look up file name
+                            this_ext_file = str(target)+this_ext
+
+                            # Verify file existence
+                            if not (os.path.isfile(indir+this_ext_file)):
+                                logger.warning("Missing needed context file: "+indir+this_ext_file)
+                                proceed = False
+
+                            # Add as param to kwarg dict
+                            kwargs_dict[param_name] = indir+this_ext_file
+
+                        if proceed == False:
+                            logger.warning("Missing some needed information. Skipping this calculation.")
+                            continue
+
+                        # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+                        # Call the moment generator
+                        # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+                        moment_generator(
+                            indir+input_file, mask=mask_file, noise=noise_in,
+                            moment=mom_params['algorithm'], 
+                            momkwargs=mom_params['kwargs'],
+                            outfile=outfile, errorfile=errorfile,
+                            channel_correlation=None)
+        # endregion
 
 else:
     # Make a mock DerivedHandler when astropy (and therefore spectral-cube)

--- a/phangsPipeline/scMaskingRoutines.py
+++ b/phangsPipeline/scMaskingRoutines.py
@@ -431,23 +431,27 @@ def make_vfield_mask(cube_in, vfield_in, window_in,
 
     vfield : float or two-d array or string
 
-    The velocity field to use as a template. If a string, it's read as
-    a Projection and reprojected onto the cube. If it's a single value
-    then this is broadcast across the whole map. If it's a two-d array
-    it is assumed to be the velocity field.
+        The velocity field to use as a template. If a string, it's read 
+        as a Projection and reprojected onto the cube. If it's a single 
+        value then this is broadcast across the whole map. If it's a 
+        two-d array it is assumed to be the velocity field.
 
-    window : float or two-d array or string
+    window : float
 
-    As velocity field in handling but this refers to the window used 
+        The velocity window about the velocity field. The window
+        is applied +/- half the input window so that the total
+        span of the window equals the input window.
+        The spectral units should match the velocity field units.
+
 
     Keywords:
     ---------
 
     vfield_hdu : optional refers to the HDU of the velocity field if a
-    file name is supplied. Default 0.
+        file name is supplied. Default 0.
 
     window_hdu : optional refers to the HDU of the velocity window if
-    a file name is supplied. Default 0.
+        a file name is supplied. Default 0.
 
     outfile : file name to write output mask to.
 
@@ -477,31 +481,16 @@ def make_vfield_mask(cube_in, vfield_in, window_in,
     # Read the velocity field to a Projection if a file is fed in
     if type(vfield_in) == str:
         vfield = Projection.from_hdu(fits.open(vfield_in)[vfield_hdu])
+    elif type(vfield_in) is Projection:
+            # ... NB making a dummy moment here because of issues with
+            # reproject and dimensionality. Could instead do header
+            # manipulation and feed in "cube"
+            dummy_mom0 = cube.moment(order=0)      
+            vfield = convert_and_reproject(vfield_in, template=dummy_mom0, unit=spunit)
     else:
-        vfield = vfield_in
-
-    # If vfield is a Projection reproject it onto the cube and match units
-    if isinstance(vfield, Projection):
-        # ... NB making a dummy moment here because of issues with
-        # reproject and dimensionality. Could instead do header
-        # manipulation and feed in "cube"
-        dummy_mom0 = cube.moment(order=0)
-        vfield = convert_and_reproject(vfield, template=dummy_mom0, unit=spunit)
-    else:
-
-        # If no units are attached to the vfield, guess that the
-        # units are the same as cube        
-        if type(vfield) != u.quantity.Quantity:
-            vfield = u.quantity.Quantity(vfield,spunit)
-        
-        # If a single value is supplied, turn it into a single-valued
-        # velocity field
-        if np.ndim(vfield.data) <= 1:
-            vfield = vfield.to(spunit)
-            vfield = u.quantity.Quantity(np.ones((ny, nx))*vfield.value, vfield.unit)
-        
-        # Just in case convert the units to match the cube
-        vfield = vfield.to(spunit)
+        logger.error('Input vfield is unknown type.')
+    
+    vfield = vfield.to(spunit)
 
     # Check sizes
     if (cube.shape[1] != vfield.shape[0]) or (cube.shape[2] != vfield.shape[1]):
@@ -525,6 +514,7 @@ def make_vfield_mask(cube_in, vfield_in, window_in,
         dummy_mom0 = cube.moment(order=0)        
         window = convert_and_reproject(window, template=dummy_mom0, unit=spunit)
     else:
+        window = window.to(spunit)
 
         # If no units are attached to the window, guess that the
         # units are the same as cube        
@@ -567,7 +557,7 @@ def make_vfield_mask(cube_in, vfield_in, window_in,
     mask = mask_around_value( \
         spaxis_cube,
         target=vfield_cube,
-        delta=window_cube)
+        delta=window_cube/2)
 
     # -------------------------------------------------
     # Output
@@ -738,13 +728,12 @@ def join_masks(orig_mask_in, new_mask_in,
         header['DATAMIN'] = 0
         hdu = fits.PrimaryHDU(np.array(mask._data, dtype=np.uint8),
                               header=header)
-        hdu.writeto(outfile, overwrite=overwrite)
-        # mask.write(outfile, overwrite=overwrite)
+        hdu.writeto(outfile, overwrite=True)
 
     return(mask)
 
 def recipe_phangs_strict_mask(
-    incube, innoise, outfile=None,
+    cube_in, innoise, outfile=None,
     coverage=None, coverage_thresh=0.95,
     mask_kwargs=None,
     return_spectral_cube=False,
@@ -780,10 +769,10 @@ def recipe_phangs_strict_mask(
 
     # TBD error checking, dimensions, types, etc.
 
-    if type(incube) is SpectralCube:
-        cube = incube
-    elif type(incube) == type("hello"):
-        cube = SpectralCube.read(incube)
+    if type(cube_in) is SpectralCube:
+        cube = cube_in
+    elif type(cube_in) == type("hello"):
+        cube = SpectralCube.read(cube_in)
     else:
         logger.error("Input cube must be a SpectralCube object or a filename.")
 
@@ -1029,6 +1018,172 @@ def recipe_phangs_broad_mask(
         header['COMMENT'] = 'Produced with PHANGS-ALMA pipeline version ' + version
         if tableversion:
             header['COMMENT'] = 'Galaxy properties from PHANGS sample table version ' + tableversion
+        hdu = fits.PrimaryHDU(np.array(mask.filled_data[:], dtype=np.uint8),
+                              header=header)
+        hdu.writeto(outfile, overwrite=overwrite)
+
+
+    if return_spectral_cube:
+        return(mask)
+    else:
+        return(mask.filled_data[:].value)
+
+
+def recipe_phangs_flat_mask(
+    cube_in, vfield_in, mask_in, 
+    vfield_hdu=0, 
+    outfile=None,
+    coverage=None, 
+    mask_kwargs=None,
+    return_spectral_cube=False,
+    overwrite=False):
+    """
+    Task to create the PHANGS-style "strict" masks.
+
+    Parameters:
+
+    -----------
+
+    cube_in : string or SpectralCube
+        The cube to be masked.
+
+
+    vfield_in : string or np.array
+        Velocity field used to define the velocity window of the 
+        flat mask.
+
+    mask_in : string or SpectralCube
+        The signal-based mask.
+
+    Keywords:
+    ---------
+    
+    vfield_hdu : optional refers to the HDU of the velocity field if a
+        file name is supplied. Default 0.
+
+    outfile : string
+        Filename where the mask will be written. The mask is also
+        returned.
+
+    masks_kwargs : dictionary
+        Parameters to be passed to the cprops masking routine.
+        Should contain the velocity window used to define a flat
+        mask.
+
+    """
+
+    # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+    # Error checking and work out inputs
+    # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+    # TBD error checking, dimensions, types, etc.
+
+    # check input cube
+    if type(cube_in) is SpectralCube:
+        cube = cube_in
+    elif type(cube_in) == str:
+        cube = SpectralCube.read(cube_in)
+    else:
+        logger.error("Input cube must be a SpectralCube object or a filename.")
+
+    cube.allow_huge_operations = True
+
+    # check input mask
+    if type(mask_in) is SpectralCube:
+        mask_signal = mask_in
+    elif type(mask_in) == str:
+        mask_signal = SpectralCube.read(mask_in)
+    else:
+        logger.error("Input mask must be a SpectralCube object or a filename.")
+
+    mask_signal.allow_huge_operations = True
+
+    # Read the velocity field to a Projection if a file is fed in
+    if type(vfield_in) == str:
+        vfield = Projection.from_hdu(fits.open(vfield_in)[vfield_hdu])
+    else:
+        vfield = vfield_in
+
+    # get dimensions and units
+    spaxis = cube.spectral_axis
+    spunit = spaxis.unit
+    spvalue = spaxis.value
+    nz, ny, nx = cube.shape
+
+    # reproject if it's a projection
+    if type(vfield) is Projection:
+        # ... NB making a dummy moment here because of issues with
+        # reproject and dimensionality. Could instead do header
+        # manipulation and feed in "cube"
+        dummy_mom0 = cube.moment(order=0)
+        vfield = convert_and_reproject(vfield, template=dummy_mom0, unit=spunit)
+
+    # check that grids match after regridding
+    if mask_signal.shape[1] != np.shape(vfield)[0]:
+        logger.error("Input velocity vfield map must be a 2D np.array of dimensions Nx, Ny, but Nx does not match..")
+    if mask_signal.shape[2] != np.shape(vfield)[1]:
+        logger.error("Input velocity vfield map must be a 2D np.array of dimensions Nx, Ny, but Ny does not match..")
+
+    if coverage is not None:
+        if type(coverage) is SpectralCube:
+            coverage_cube = coverage
+        elif type(coverage) == type("hello"):
+            coverage_cube = SpectralCube.read(coverage)
+        else:
+            logger.error("Coverage cube must be a SpectralCube object or a filename or None.")
+
+        coverage_cube.allow_huge_operations = True
+
+    # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+    # Set up the masking kwargs
+    # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+    # Initialize an empty kwargs dictionary
+    if mask_kwargs is None:
+        mask_kwargs = {}
+
+    # Fill in strict mask defaults
+    if 'window' not in mask_kwargs:
+        mask_kwargs['window'] = '50km/s'
+
+
+    # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+    # Create the mask
+    # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+    # prior_hi = None
+    # if coverage is not None:
+    #     prior_hi = coverage_cube.filled_data[:].value > coverage_thresh
+
+    # create mask around velocity centroid with fixed velocity window
+    window =u.Quantity(mask_kwargs['window'])
+    mask_window = make_vfield_mask(cube, vfield, window,
+                                   outfile=None, overwrite=True)
+
+    # combine signal and window mask
+    mask = join_masks(mask_signal, mask_window,
+                      order='fast_nearest_neighbor', 
+                      operation='or',
+                      thresh=0.5, outfile=None)
+    mask = mask.filled_data[:].value
+
+    # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+    # Write to disk and return
+    # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+    # In this case can avoid a recast
+    if not return_spectral_cube and (outfile is None):
+        return(mask)
+
+    # Recast from numpy array to spectral cube
+    mask = SpectralCube(mask*1.0, wcs=cube.wcs, header=cube.header,
+                        meta={'BUNIT': ' ', 'BTYPE': 'Mask'})
+
+    # Write to disk, if desired
+    if outfile is not None:
+        header = mask.header
+        header['DATAMAX'] = 1
+        header['DATAMIN'] = 0
         hdu = fits.PrimaryHDU(np.array(mask.filled_data[:], dtype=np.uint8),
                               header=header)
         hdu.writeto(outfile, overwrite=overwrite)

--- a/phangsPipeline/scMoments.py
+++ b/phangsPipeline/scMoments.py
@@ -50,6 +50,9 @@ def _func_and_kwargs_for_moment(moment_tag=None):
     elif moment_tag == 'mom1wprior':
         func = scdr.write_moment1_hybrid
         kwargs = {'unit': u.km / u.s}
+    elif moment_tag == 'mom0flat':
+        func = scdr.write_moment0_flat
+        kwargs ={'unit': u.K * u.km / u.s}
 
     return(func, kwargs)
 

--- a/phangsPipeline/scStackingRoutines.py
+++ b/phangsPipeline/scStackingRoutines.py
@@ -43,6 +43,7 @@ def channelShiftVec(x, ChanShift):
     
     return(x2)
 
+
 def ShuffleCube(
         cube_in, vfield_in, vfield_hdu=0,
         outfile=None, overwrite=True,
@@ -59,16 +60,16 @@ def ShuffleCube(
 
     vfield : float or two-d array or string
 
-    The velocity field to use as a reference. If a string, it's read
-    as a Projection and reprojected onto the cube. If it's a single
-    value then this is broadcast across the whole map. If it's a two-d
-    array it is assumed to be the velocity field.
+        The velocity field to use as a reference. If a string, it's read
+        as a Projection and reprojected onto the cube. If it's a single
+        value then this is broadcast across the whole map. If it's a two-d
+        array it is assumed to be the velocity field.
     
     Keywords
     --------
 
     vfield_hdu : optional refers to the HDU of the velocity field if a
-    file name is supplied. Default 0.
+        file name is supplied. Default 0.
 
     chunk : int
         Number of data points to include in a chunk for processing.
@@ -93,8 +94,10 @@ def ShuffleCube(
     else:
         cube = cube_in
 
-    spaxis = cube.spectral_axis        
+    spaxis = cube.spectral_axis
     spunit = spaxis.unit
+    spvalue = spaxis.value
+    nz, ny, nx = cube.shape
     
     # -------------------------------------------------
     # Now read and align the velocity field
@@ -238,9 +241,216 @@ def ShuffleCube(
     return(new_cube)
 
 
-def BinByMask(DataCube, mask, centroid_map, weight_map=None):
+def recipe_phangs_vfield(
+    vfield_in,
+    vfield_in_hdu=0,
+    list_of_vfields=None,
+    outfile=None,
+    overwrite=False):
     """
-    Bin a data cube by a label mask, aligning the data to a common centroid.  Returns an array.
+    Task to create combined velocity field from a list of velocity maps in
+    a hierarchical manner (from first to last).
+
+    Parameters:
+
+    -----------
+
+    vfield_in : string or fits.hdu
+
+        The reference velocity filed that holds the target WCS. The 
+        other maps will be reprojected onto this one. This map is 
+        included in the final output.
+
+    Keywords:
+    ---------
+
+    vfield_in_hdu : 
+
+    list_of_vfields : list or list of fits.hdu
+
+        List of velocity fields or fits.hdus. These will be reprojected
+        onto the template vfield and then combined via hierarchical addition.
+
+    outfile : string
+        Filename where the vfield will be written. The vfield maps is alsoreturned.
+
+    """
+
+    # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+    # Read in template velocity field
+    # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+    # Read the velocity field to a Projection if a file is fed in
+    if type(vfield_in) == str:
+        template_vfield = Projection.from_hdu(fits.open(vfield_in)[vfield_in_hdu])
+    else:
+        template_vfield = vfield_in
+
+    # get velocity unit
+    spunit = template_vfield.unit
+
+    # initialise combined velocity field
+    vfield_combined = np.copy(template_vfield)
+    vfield_combined[np.isnan(vfield_combined)] = 0
+
+    # loop over list of velocity fields
+    for this_vfield_in in list_of_vfields:
+
+        # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+        # Read in and align ancillary velocity field
+        # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+        # Read the velocity field to a Projection if a file is fed in
+        if type(this_vfield_in) == str:
+            this_vfield = Projection.from_hdu(fits.open(this_vfield_in)[vfield_in_hdu])
+        else:
+            this_vfield = this_vfield_in
+
+        # print(this_vfield)
+
+        # If vfield is a Projection reproject it onto the cube and match units
+        if type(this_vfield) is Projection:
+            this_vfield = convert_and_reproject(this_vfield, template=template_vfield, unit=spunit)
+        else:
+
+            # If no units are attached to the vfield, guess that the
+            # units are the same as cube        
+            if type(this_vfield) != u.quantity.Quantity:
+                this_vfield = u.quantity.Quantity(this_vfield, spunit)
+            
+            # Just in case convert the units to match the cube
+            this_vfield = this_vfield.to(spunit)
+
+        # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+        # Merge velocity fields
+        # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+        # fill empty area with current vfield
+        mom1_temp = np.copy(this_vfield)
+        mom1_temp[vfield_combined != 0] = 0
+        vfield_combined += mom1_temp
+        vfield_combined[np.isnan(vfield_combined)] = 0
+
+    # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+    # Write or return as requested
+    # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+    # prepate velocity field for output
+    vfield_combined[vfield_combined == 0] = np.nan
+
+    # Write to disk, if desired
+    if outfile is not None:
+        fits.writeto(outfile, vfield_combined.value, template_vfield.header, overwrite=overwrite)
+
+    # return combined velocity field
+    return(vfield_combined)
+
+def recipe_shuffle_cube(
+    cube_in,
+    vfield_in,
+    vfield_in_hdu=0,
+    outfile=None,
+    return_spectral_cube=False,
+    overwrite=False):
+    """
+    Task to create velocity-shuffled cubes via input velocity vfield map.
+
+    Parameters:
+    -----------
+
+    cube_in : string or SpectralCube
+        The cube to be masked.
+
+    vfield_in : 2D numpy.ndarray
+        A 2D map of the vfield velocities for the lines to stack of dimensions Nx, Ny.
+        Note that DataCube and vfield map must have equivalent (but not necessarily equal) 
+        spectral units (e.g., km/s and m/s)
+    
+
+    Keywords:
+    ---------
+
+    vfield_in_hdu=,
+
+    outfile : string
+        Filename where the shuffled cube will be written. The shuffled cube is also
+        returned.
+
+    """
+
+    # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+    # Error checking and work out inputs
+    # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+    # check input cube
+    if type(cube_in) is SpectralCube:
+        cube = cube_in
+    elif type(cube_in) == type("hello"):
+        cube = SpectralCube.read(cube_in)
+    else:
+        logger.error("Input cube must be a SpectralCube object or a filename.")
+
+    cube.allow_huge_operations = True
+
+    spaxis = cube.spectral_axis
+    spunit = spaxis.unit
+
+    # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+    # Read in and align velocity field
+    # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+    # Read the velocity field to a Projection if a file is fed in
+    if type(vfield_in) == str:
+        vfield = Projection.from_hdu(fits.open(vfield_in)[vfield_in_hdu])
+    else:
+        vfield = vfield_in
+
+    # If vfield is a Projection reproject it onto the cube and match units
+    if type(vfield) is Projection:
+        # ... NB making a dummy moment here because of issues with
+        # reproject and dimensionality. Could instead do header
+        # manipulation and feed in "cube"
+        dummy_mom0 = cube.moment(order=0)
+        vfield = convert_and_reproject(vfield, template=dummy_mom0, unit=spunit)
+    else:
+
+        # If no units are attached to the vfield, guess that the
+        # units are the same as cube        
+        if type(vfield) != u.quantity.Quantity:
+            vfield = u.quantity.Quantity(vfield, spunit)
+        
+        # Just in case convert the units to match the cube
+        vfield = vfield.to(spunit)
+
+    # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+    # Run the shuffling
+    # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+    # run shuffling
+    shuffled_cube = ShuffleCube(cube, vfield, chunk=1000)    
+
+    # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+    # Write or return as requested
+    # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
+
+    # prepare cube for output
+    # convert data type to 32-bit float and assign WCS and header
+    shuffled_cube = SpectralCube(shuffled_cube.filled_data[:].astype(np.float32), wcs=shuffled_cube.wcs, header=shuffled_cube.header)
+
+    # Write to disk, if desired
+    if outfile is not None:
+        shuffled_cube.write(outfile, overwrite=overwrite)
+
+    # return cube
+    if return_spectral_cube:
+        return(shuffled_cube)
+    else:
+        return(shuffled_cube.filled_data[:].value)
+
+
+def BinByMask(DataCube, mask, vfield, weight_map=None):
+    """
+    Bin a data cube by a label mask, aligning the data to a common vfield.  Returns an array.
 
     Parameters
     ----------
@@ -248,9 +458,9 @@ def BinByMask(DataCube, mask, centroid_map, weight_map=None):
         The original spectral cube with spatial dimensions Nx, Ny and spectral dimension Nv
     Mask : 2D numpy.ndarray
         A 2D map containing boolean values with True indicate where the spectra should be aggregated.
-    centroid_map : 2D numpy.ndarray
-        A 2D map of the centroid velocities for the lines to stack of dimensions Nx, Ny.
-        Note that DataCube and Centroid map must have equivalent spectral units (e.g., km/s)
+    vfield : 2D numpy.ndarray
+        A 2D map of the vfield velocities for the lines to stack of dimensions Nx, Ny.
+        Note that DataCube and vfield map must have equivalent spectral units (e.g., km/s)
     weight_map : 2D numpy.ndarray
         Map containing the weight values to be used in averaging
     Returns
@@ -262,9 +472,9 @@ def BinByMask(DataCube, mask, centroid_map, weight_map=None):
     y, x = np.where(mask)
     v0 = spaxis[len(spaxis) // 2] * DataCube.spectral_axis.unit
     relative_channel = np.arange(len(spaxis)) - (len(spaxis) // 2)
-    centroids = centroid_map[y, x].to(DataCube.spectral_axis.unit).value
+    vfields = vfield[y, x].to(DataCube.spectral_axis.unit).value
     sortindex = np.argsort(spaxis)
-    channel_shift = -1 * np.interp(centroids, spaxis[sortindex],
+    channel_shift = -1 * np.interp(vfields, spaxis[sortindex],
                                    np.array(relative_channel[sortindex], dtype=float))
     spectra = DataCube.filled_data[:, y, x].value
     shifted_spectra = channelShiftVec(spectra, channel_shift)
@@ -278,11 +488,11 @@ def BinByMask(DataCube, mask, centroid_map, weight_map=None):
     return(accum_spectrum, shifted_spaxis)
 
 
-def BinByLabel(DataCube, LabelMap, centroid_map,
+def BinByLabel(DataCube, LabelMap, vfield,
                weight_map=None,
                background_labels=[0]):
     """
-    Bin a data cube by a label mask, aligning the data to a common centroid.
+    Bin a data cube by a label mask, aligning the data to a common vfield.
 
     Parameters
     ----------
@@ -290,9 +500,9 @@ def BinByLabel(DataCube, LabelMap, centroid_map,
         The original spectral cube with spatial dimensions Nx, Ny and spectral dimension Nv
     LabelMap : 2D numpy.ndarray
         A 2D map containing integer labels for each pixel into objects defining the stacking.
-    centroid_map : 2D numpy.ndarray
-        A 2D map of the centroid velocities for the lines to stack of dimensions Nx, Ny.
-        Note that DataCube and Centroid map must have equivalent spectral units to DataCube
+    vfield : 2D numpy.ndarray
+        A 2D map of the vfield velocities for the lines to stack of dimensions Nx, Ny.
+        Note that DataCube and vfield map must have equivalent spectral units to DataCube
     background_labels : list
         List of values in the label map that correspond to background objects and should not
         be processed with the stacking. 
@@ -309,7 +519,7 @@ def BinByLabel(DataCube, LabelMap, centroid_map,
         if ThisLabel not in background_labels:
             thisspec, spaxis = BinByMask(DataCube,
                                          (LabelMap == ThisLabel),
-                                         centroid_map,
+                                         vfield,
                                          weight_map=weight_map)
             output_list += [{'label': ThisLabel,
                              'spectrum': thisspec,

--- a/phangsPipeline/utilsKeyReaders.py
+++ b/phangsPipeline/utilsKeyReaders.py
@@ -36,6 +36,7 @@ def test_readers(root=''):
     test = read_override_key(root + 'key_templates/overrides.txt')
 
     test = read_distance_key(root + 'key_templates/distance_key.txt')
+    test = read_window_key(root + 'key_templates/vwindow_key.txt')
 
 
 ##############################################################
@@ -401,6 +402,51 @@ def read_distance_key(fname='', existing_dict=None, delim=None):
     # return out_dict
     return out_dict
 
+def read_window_key(fname='', existing_dict=None, delim=None):
+    """
+    Read a velocity window key.
+    """
+    #
+    # Initialize the dictionary
+    if existing_dict is None:
+        out_dict = {}
+    else:
+        out_dict = existing_dict
+    #
+    # Check file existence
+    if not os.path.isfile(fname):
+        logger.error("I tried to read key " + fname + " but it does not exist.")
+        return out_dict
+    #
+    # Read file
+    logger.info("Reading: " + fname)
+
+    delim = ',' if delim is None else delim
+
+    lines = [re.sub('[' + delim + ']+', delim, t) for t in open(fname, 'r').readlines()]  # compress multiple delim
+
+    lines = [t for t in lines if ((not t.startswith('#')) and (t.strip() != '') and (t.count(delim) == 1))]
+
+    lines_read = 0
+    for t in lines:
+        name = t.split(delim)[0]
+        if name.strip() == 'galaxy':
+            continue
+        window_kms = t.split(delim)[1].strip()
+        try:
+            str(window_kms)
+        except ValueError:
+            continue
+
+        out_dict[name] = {}
+        out_dict[name]['window'] = window_kms+'km/s'
+        lines_read += 1
+
+        # note that the first line of the csv is also read in. but no one will input target='galaxy' anyway.
+    logger.info("Read " + str(lines_read) + " lines into a target/vwindow dictionary.")
+    #
+    # return out_dict
+    return out_dict
 
 def read_nametoname_key(fname='', existing_dict=None, delim=None, as_list=False):
     """

--- a/run_derived_pipeline_phangs-alma.py
+++ b/run_derived_pipeline_phangs-alma.py
@@ -101,6 +101,12 @@ do_broadmask = True
 do_moments = True
 do_secondary = True
 
+# new DR5 routines (shuffling and flat maps)
+do_vfield = False    # creates a velocity field for shuffling
+do_shuffling = True # runs independently from other tasks
+do_flatmask = True  # requires noise and broad/flat masks
+do_flatmaps = True  # requires flat masks
+
 ##############################################################################
 # Step through derived product creation
 ##############################################################################
@@ -155,3 +161,44 @@ if do_secondary:
     this_der.loop_derive_products(do_convolve=False, do_noise=False,
                                   do_strictmask=False, do_broadmask=False,
                                   do_moments=False, do_secondary=True)
+
+# Create velocity field. This creates a combined velocity field from 
+# a list of derived mom1 maps.
+
+if do_vfield:
+    this_der.loop_derive_products(do_convolve=False, do_noise=False,
+                                  do_strictmask=False, do_broadmask=False,
+                                  do_moments=False, do_secondary=False,
+                                  do_vfield=True, do_shuffling=False, 
+                                  do_flatmask=False, do_flatmaps=False)    
+    
+# Create shuffled cubes. This shuffles the processed and derived cubes
+# by a velocity offset defined by an input velocity field.
+
+if do_shuffling:
+    this_der.loop_derive_products(do_convolve=False, do_noise=False,
+                                  do_strictmask=False, do_broadmask=False,
+                                  do_moments=False, do_secondary=False,
+                                  do_vfield=False, do_shuffling=True, 
+                                  do_flatmask=False, do_flatmaps=False)    
+
+# Construct flat masks. This combines the existing signal masks
+# with a velocity slab based on a input velocity field and velocity 
+# window.
+
+if do_flatmask:
+    this_der.loop_derive_products(do_convolve=False, do_noise=False,
+                                  do_strictmask=False, do_broadmask=False,
+                                  do_moments=False, do_secondary=False,
+                                  do_vfield=False, do_shuffling=False, 
+                                  do_flatmask=True, do_flatmaps=False)
+
+# Produce flat moment-0 maps. This uses the flat masks to create 
+# moment-0 maps.
+
+if do_flatmaps:
+    this_der.loop_derive_products(do_convolve=False, do_noise=False,
+                                  do_strictmask=False, do_broadmask=False,
+                                  do_moments=False, do_secondary=False,
+                                  do_vfield=False, do_shuffling=False, 
+                                  do_flatmask=False, do_flatmaps=True)


### PR DESCRIPTION
Implementation of a new routine to compute shuffled cubes and flat maps (mom-0 maps from shuffled cubes using a fixed velocity window) given 1) a provided velocity field or 2) using the (smoothed) mom-1 from the pipeline as a velocity field.

This implementation uses the existing routines to compute products (i.e. moments) and adds new ppv masks and flat maps in two versions, a flat and a broad mask version.

This feature also requires a new file, called "window_key.txt", to specify the velocity window(s) of the target(s).

The implementation only affects the derived products stages of the pipeline and can be run as usual via the "run_derived_pipeline_phangs-alma.py" script or using "example_make_products.py".

PS: This pull request replaced (superseeds) a previous pull request with the same purpose.