### PR TITLE
Initial noise convergence test implementation and outline noise-only simulated obs for testing

### DIFF
--- a/phangsPipeline/casaImagingRoutines.py
+++ b/phangsPipeline/casaImagingRoutines.py
@@ -406,20 +406,119 @@ def execute_clean_call(
         if active_kwargs['pblimit'] > active_kwargs['pbmask']:
             active_kwargs['pbmask'] = active_kwargs['pblimit']
 
+    active_kwargs['fullsummary'] = True
+
     if imaging_method == 'tclean':
         # os.mkdir(clean_call.get_param('imagename')+'.image'+'.touch') #<TODO><DEBUG><DL>#
-        casaStuff.tclean(**active_kwargs)
+        tclean_result = casaStuff.tclean(**active_kwargs)
         # os.rmdir(clean_call.get_param('imagename')+'.image'+'.touch') #<TODO><DEBUG><DL>#
     elif imaging_method == 'sdintimaging':
-        casaStuff.sdintimaging(**active_kwargs)
+        tclean_result = casaStuff.sdintimaging(**active_kwargs)
+    else:
+        logger.error('Unexpected imaging method %s' % imaging_method)
+        raise Exception('Unexpected imaging method %s' % imaging_method)
 
     if clean_call.logfile != None:
         casaStuff.casalog.setlogfile(oldlogfile)
 
-    return
+    return tclean_result
 
 
 # endregion
+
+
+def check_noise_convergence(tclean_summary, noise, gain, last_n_cycles=3, z_threshold=2.0,
+                            verbose=False, n_pix=None):
+    """
+    Statistical convergence test: are the recent CLEAN components consistent
+    with noise rather than signal?
+
+    Under H0 (noise only), CLEAN selects the extremum of the residual image at
+    each minor cycle. For n_pix finite pixels the extremum is drawn from both
+    tails of the Gaussian, so Var(extremum) ≈ 2·ln(2·n_pix)·(gain·noise)^2.
+    The sum S of N_total such extremal draws has
+    Std(S) = sqrt(N_total) · gain · noise · sqrt(2·ln(2·n_pix)).
+    When n_pix is None the older formula Std(S) = sqrt(N_total)·gain·noise
+    is used as a backward-compatible fallback.
+
+    Parameters
+    ----------
+    tclean_summary : dict
+        Return value of tclean with fullsummary=True.
+    noise : float
+        RMS noise estimate (Jy/beam), e.g. from noise_for_cube().
+    gain : float
+        CLEAN loop gain (typically 0.1).
+    last_n_cycles : int
+        Number of trailing major cycles from the tclean call to include.
+    z_threshold : float
+        |z| < z_threshold declares components consistent with noise (converged).
+    verbose : bool
+        Print summary info.
+    n_pix : int or None
+        Number of finite pixels in the primary-beam image. When provided,
+        enables the extreme-value variance correction. When None, falls back
+        to the simpler random-sampling formula.
+    Returns
+    -------
+    dict with keys: z_score, N_components, flux_sum, std_expected, converged
+    None if summary is unavailable or malformed.
+    """
+
+    if tclean_summary is None or not isinstance(tclean_summary, dict):
+        return None
+    if 'summaryminor' not in tclean_summary:
+        return None
+
+    summaryminor = tclean_summary['summaryminor']
+    total_flux_increment = 0.0
+    total_iter_done = 0
+
+    for field in summaryminor:
+        for chan in summaryminor[field]:
+            for pol in summaryminor[field][chan]:
+                data = summaryminor[field][chan][pol]
+                try:
+                    iter_done = np.array(data['iterDone'])
+                    model_flux = np.array(data['modelFlux'])
+                    start_flux = np.array(data['startModelFlux'])
+                except (KeyError, TypeError):
+                    continue
+                n_cycles = len(iter_done)
+                if n_cycles == 0:
+                    continue
+                window = min(last_n_cycles, n_cycles)
+                total_flux_increment += float(
+                    np.sum(model_flux[-window:] - start_flux[-window:]))
+                total_iter_done += int(np.sum(iter_done[-window:]))
+
+    if total_iter_done == 0:
+        return {'z_score': 0.0, 'converged': True,
+                'N_components': 0, 'flux_sum': 0.0, 'std_expected': 0.0}
+
+    if n_pix is not None and n_pix > 1:
+        # Extreme-value correction: CLEAN picks the extremum of the noise field.
+        # Both positive max and negative min contribute → factor 2·n_pix.
+        std_expected = (np.sqrt(total_iter_done) * abs(gain) * float(noise)
+                        * np.sqrt(2.0 * np.log(2.0 * n_pix)))
+    else:
+        # Backward-compatible fallback: random-sampling formula.
+        std_expected = np.sqrt(total_iter_done) * abs(gain) * float(noise)
+
+    z_score = total_flux_increment / std_expected if std_expected > 0.0 else 0.0
+
+    if verbose:
+        print('z_score', z_score, 'total_iter_done', total_iter_done,
+            'total_flux_increment', total_flux_increment,
+            'std_expected', std_expected)
+
+    return {
+        'z_score': float(z_score),
+        'N_components': total_iter_done,
+        'flux_sum': total_flux_increment,
+        'std_expected': float(std_expected),
+        'converged': abs(z_score) < z_threshold,
+    }
 
 # &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
 # Run a clean call with NITER=0 to make a dirty image
@@ -546,6 +645,8 @@ def clean_loop(
         stop_at_negative=True,
         remask_each_loop=False,
         force_dirty_image=False,
+        convergence_noise_z_threshold=None,
+        convergence_noise_window=3,
 ):
     """
     Carry out an iterative clean until a convergence criteria is
@@ -637,7 +738,7 @@ def clean_loop(
     # Create a text record of progress through successive clean calls.
 
     record = []
-    record.append("loopnum, deconvolver, niter, cycleniter, threshold, noise, model_flux, frac_delta_flux\n")
+    record.append("loopnum, deconvolver, niter, cycleniter, threshold, noise, model_flux, frac_delta_flux, noise_z_score\n")
     record.append("# column 1: Loop number.\n")
     record.append("# column 2: Deconvolver used in clean.\n")
     record.append("# column 3: Allocated number of iterations.\n")
@@ -646,6 +747,7 @@ def clean_loop(
     record.append("# column 6: Noise level measured in residuals.\n")
     record.append("# column 7: Integrated model flux.\n")
     record.append("# column 8: Fractional change in flux from previous loop.\n")
+    record.append("# column 9: Noise z-score.\n")
 
     # Initialize the loop counter and our tracking of the flux in the
     # model (which we use to estimate convergence).
@@ -774,9 +876,9 @@ def clean_loop(
 
         # Execute the clean call.
 
-        execute_clean_call(working_call,
-                           imaging_method=imaging_method,
-                           convergence_fracflux=convergence_fracflux)
+        tclean_summary = execute_clean_call(working_call,
+                                            imaging_method=imaging_method,
+                                            convergence_fracflux=convergence_fracflux)
 
         # Calculate the new model flux and the change relative to the
         # previous step, normalized by current flux and by iterations.
@@ -797,6 +899,10 @@ def clean_loop(
 
         flux_per_iter = delta_flux / niter
         frac_delta_flux = delta_flux / previous_flux
+
+        # If we don't have any model flux after iter 1, then catch that here
+        if np.isnan(frac_delta_flux) and loop > 0:
+            frac_delta_flux = 0
 
         # Check whether the model flux convergence criteria is met
 
@@ -823,6 +929,46 @@ def clean_loop(
             if current_flux < 0.0:
                 proceed = False
 
+        # Statistical noise convergence check: are the recent CLEAN components
+        # consistent with noise draws rather than signal? Uses the conservative
+        # variance bound Var(S) = N*(gain*noise)^2.
+
+        if convergence_noise_z_threshold is not None:
+            n_pix = None
+            _imagename = working_call.get_param('imagename')
+            pb_image = (_imagename + '.pb') if _imagename else None
+            if pb_image and os.path.isdir(pb_image):
+                try:
+                    myia = au.createCasaTool(casaStuff.iatool)
+                    myia.open(pb_image)
+                    pb_data = myia.getchunk()
+                    myia.close()
+                    n_pix = int(np.sum(np.isfinite(pb_data)))
+                except Exception:
+                    n_pix = None
+            noise_conv = check_noise_convergence(
+                tclean_summary=tclean_summary,
+                noise=current_noise,
+                gain=working_call.get_param('gain') or 0.1,
+                last_n_cycles=convergence_noise_window,
+                z_threshold=convergence_noise_z_threshold,
+                n_pix=n_pix,
+            )
+            if noise_conv is not None:
+                logger.info(
+                    "Noise convergence: z=%.2f, N=%d, n_pix=%s, flux_sum=%.4e Jy, "
+                    "std_expected=%.4e Jy, converged=%s" % (
+                        noise_conv['z_score'], noise_conv['N_components'],
+                        str(n_pix),
+                        noise_conv['flux_sum'], noise_conv['std_expected'],
+                        str(noise_conv['converged'])))
+                if noise_conv['converged']:
+                    proceed = False
+            else:
+                noise_conv = None
+        else:
+            noise_conv = None
+
         # Enforce minimum and maximum limits on number of loops. These
         # override other convergence criteria.
 
@@ -841,7 +987,8 @@ def clean_loop(
         this_record += str(working_call.get_param('threshold')) + ', '
         this_record += str(current_noise) + 'Jy/beam, '
         this_record += str(current_flux) + 'Jy*chan, '
-        this_record += str(frac_delta_flux) + ''
+        this_record += str(frac_delta_flux) + ', '
+        this_record += str(noise_conv['z_score'] if noise_conv is not None else 'N/A')
         this_record += '\n'
 
         # Print the current record to the screen

--- a/phangsPipeline/casaStuff.py
+++ b/phangsPipeline/casaStuff.py
@@ -204,3 +204,6 @@ if casa_version[0] < 5:
 # sdintimaging import
 if (casa_version[0] >= 6):
     from .taskSDIntImaging import sdintimaging
+    # TODO: switch to casatask version of sdintimaging
+    # from casatasks import sdintimaging
+

--- a/phangsPipeline/handlerImaging.py
+++ b/phangsPipeline/handlerImaging.py
@@ -190,6 +190,7 @@ if casa_enabled:
                 do_revert_to_singlescale=False,
                 do_export_to_fits=False,
                 convergence_fracflux=0.01,
+                convergence_noise_z_threshold=None,
                 singlescale_threshold_value=1.0,
                 extra_ext_in=None,
                 suffix_in=None,
@@ -207,6 +208,74 @@ if casa_enabled:
             configurations to do the imaging. Toggle the parts of the loop
             using the do_XXX booleans. Other choices affect algorithms
             used.
+
+            The clean convergence is set by the convergence_fracflux and
+            convergence_noise_z_threshold parameters.
+            - convergence_fracflux is the fractional flux threshold between imaging loops.
+                Convergence is reached when the fractional flux change is less than this value.
+            - convergence_noise_z_threshold is the noise threshold in z-scores.
+                Convergence is reached when the z-score test is less than this value. By default,
+                this is disabled by setting to None. We suggest setting this to 2.0 when enabled
+                as a conservative choice.
+
+            Parameters
+            ----------
+            do_all : bool
+                If True, do all steps.
+            imaging_method : str
+                'tclean' or 'sdintimaging'
+            do_dirty_image : bool
+                If True, make a dirty image.
+            do_revert_to_dirty : bool
+                If True, revert to dirty image.
+            do_read_clean_mask : bool
+                If True, read clean mask.
+            do_multiscale_clean : bool
+                If True, multiscale clean.
+            do_revert_to_multiscale : bool
+                If True, revert to multiscale clean.
+            do_singlescale_mask : bool
+                If True, make singlescale mask.
+            singlescale_mask_high_snr : float
+                High SNR threshold for singlescale mask.
+            singlescale_mask_low_snr : float
+                Low SNR threshold for singlescale mask.
+            singlescale_mask_absolute : bool
+                If True, use absolute threshold for singlescale mask.
+            do_singlescale_clean : bool
+                If True, singlescale clean.
+            do_revert_to_singlescale : bool
+                If True, revert to singlescale clean.
+            do_export_to_fits : bool
+                If True, export ms data folders into fits-format image cube files.
+            convergence_fracflux : float
+                Fractional flux convergence threshold for multiscale clean. Default is 0.01.
+            convergence_noise_z_threshold : float
+                Noise convergence threshold for multiscale clean. Default is None. A suggested
+                value to use is 2.0, i.e. the null hypothesis is rejected if the z-score is
+                greater than 2.0.
+            singlescale_threshold_value : float
+                Threshold value for singlescale clean. Default is 1.0.
+            extra_ext_in : str
+                Extra extension for input files.
+            suffix_in : str
+                Suffix for input files.
+            extra_ext_out : str
+                Extra extension for output files.
+            recipe : str
+                The recipe. Default is 'phangsalma'.
+            make_directories : bool
+                Create missing directories.
+            dynamic_sizing : bool
+                Use dynamic sizing.
+            force_square : bool
+                Force the image size to be square.
+            export_dirty : bool
+                If True, export dirty images.
+            export_multiscale : bool
+                If True, export multiscale images.
+            overwrite : bool
+                Overwrite existing files.
             """
 
             if do_all:
@@ -259,7 +328,7 @@ if casa_enabled:
                 logger.info("--------------------------------------------------------")
                 logger.info('Imaging recipe: ' + recipe)
 
-                #<20241113><DZLIU># 
+                #<20241113><DZLIU>#
                 skip = False
                 if not overwrite:
                     do_dirty_image = True
@@ -320,6 +389,7 @@ if casa_enabled:
                         do_revert_to_singlescale=do_revert_to_singlescale,
                         do_export_to_fits=do_export_to_fits,
                         convergence_fracflux=convergence_fracflux,
+                        convergence_noise_z_threshold=convergence_noise_z_threshold,
                         singlescale_threshold_value=singlescale_threshold_value,
                         dynamic_sizing=dynamic_sizing,
                         force_square=force_square,
@@ -810,6 +880,7 @@ if casa_enabled:
                 clean_call=None,
                 imaging_method='tclean',
                 convergence_fracflux=0.01,
+                convergence_noise_z_threshold=None,
                 backup=True,
         ):
             """
@@ -863,6 +934,7 @@ if casa_enabled:
                            stop_at_negative=True,
                            remask_each_loop=False,
                            force_dirty_image=False,
+                           convergence_noise_z_threshold=convergence_noise_z_threshold,
                            )
             # log_ext='multiscale',
             if backup:
@@ -981,6 +1053,7 @@ if casa_enabled:
                 imaging_method='tclean',
                 convergence_fracflux=0.01,
                 threshold_value=1.0,
+                convergence_noise_z_threshold=None,
                 backup=True,
         ):
             """
@@ -1034,6 +1107,7 @@ if casa_enabled:
                            stop_at_negative=False,
                            remask_each_loop=False,
                            force_dirty_image=False,
+                           convergence_noise_z_threshold=convergence_noise_z_threshold,
                            )
             # log_ext='singlescale',
             if backup:
@@ -1099,6 +1173,7 @@ if casa_enabled:
                 do_revert_to_singlescale=True,
                 do_export_to_fits=True,
                 convergence_fracflux=0.01,
+                convergence_noise_z_threshold=None,
                 singlescale_threshold_value=1.0,
                 dynamic_sizing=True,
                 force_square=False,
@@ -1287,6 +1362,7 @@ if casa_enabled:
                 self.task_multiscale_clean(clean_call=clean_call,
                                            imaging_method=imaging_method,
                                            convergence_fracflux=convergence_fracflux,
+                                           convergence_noise_z_threshold=convergence_noise_z_threshold,
                                            )
 
             if do_export_to_fits and export_multiscale:
@@ -1331,6 +1407,7 @@ if casa_enabled:
                 self.task_singlescale_clean(clean_call=clean_call,
                                             imaging_method=imaging_method,
                                             convergence_fracflux=convergence_fracflux,
+                                            convergence_noise_z_threshold=convergence_noise_z_threshold,
                                             threshold_value=singlescale_threshold_value,
                                             )
 

--- a/phangsPipeline/handlerImagingChunked.py
+++ b/phangsPipeline/handlerImagingChunked.py
@@ -328,6 +328,7 @@ if casa_enabled:
                 do_export_to_fits=True,
                 do_cleanup=True,
                 convergence_fracflux=0.01,
+                convergence_noise_z_threshold=None,
                 singlescale_threshold_value=1.0,
                 extra_ext_in=None,
                 suffix_in=None,
@@ -337,10 +338,76 @@ if casa_enabled:
                 overwrite=False,
                 ):
             """
-            Loops over the full set of targets, products, and
-            configurations to do the imaging. Toggle the parts of the loop
-            using the do_XXX booleans. Other choices affect algorithms
-            used.
+            Run the imaging process.
+
+            The clean convergence is set by the convergence_fracflux and
+            convergence_noise_z_threshold parameters.
+            - convergence_fracflux is the fractional flux threshold between imaging loops.
+                Convergence is reached when the fractional flux change is less than this value.
+            - convergence_noise_z_threshold is the noise threshold in z-scores.
+                Convergence is reached when the z-score test is less than this value. By default,
+                this is disabled by setting to None. We suggest setting this to 2.0 when enabled
+                as a conservative choice.
+
+            Parameters
+            ----------
+            do_all : bool
+                If True, do all steps.
+            imaging_method : str
+                'tclean' or 'sdintimaging'
+            do_dirty_image : bool
+                If True, make a dirty image.
+            do_revert_to_dirty : bool
+                If True, revert to dirty image.
+            do_read_clean_mask : bool
+                If True, read clean mask.
+            do_multiscale_clean : bool
+                If True, multiscale clean.
+            do_revert_to_multiscale : bool
+                If True, revert to multiscale clean.
+            do_singlescale_mask : bool
+                If True, make singlescale mask.
+            singlescale_mask_high_snr : float
+                High SNR threshold for singlescale mask.
+            singlescale_mask_low_snr : float
+                Low SNR threshold for singlescale mask.
+            singlescale_mask_absolute : bool
+                If True, use absolute threshold for singlescale mask.
+            do_singlescale_clean : bool
+                If True, singlescale clean.
+            do_revert_to_singlescale : bool
+                If True, revert to singlescale clean.
+            do_export_to_fits : bool
+                If True, export ms data folders into fits-format image cube files.
+            convergence_fracflux : float
+                Fractional flux convergence threshold for multiscale clean. Default is 0.01.
+            convergence_noise_z_threshold : float
+                Noise convergence threshold for multiscale clean. Default is None. A suggested
+                value to use is 2.0, i.e. the null hypothesis is rejected if the z-score is
+                greater than 2.0.
+            singlescale_threshold_value : float
+                Threshold value for singlescale clean. Default is 1.0.
+            extra_ext_in : str
+                Extra extension for input files.
+            suffix_in : str
+                Suffix for input files.
+            extra_ext_out : str
+                Extra extension for output files.
+            recipe : str
+                The recipe. Default is 'phangsalma'.
+            make_directories : bool
+                Create missing directories.
+            dynamic_sizing : bool
+                Use dynamic sizing.
+            force_square : bool
+                Force the image size to be square.
+            export_dirty : bool
+                If True, export dirty images.
+            export_multiscale : bool
+                If True, export multiscale images.
+            overwrite : bool
+                Overwrite existing files.
+
             """
 
             if do_all:
@@ -401,6 +468,7 @@ if casa_enabled:
                     do_export_to_fits=do_export_to_fits,
                     do_cleanup=do_cleanup,
                     convergence_fracflux=convergence_fracflux,
+                    convergence_noise_z_threshold=convergence_noise_z_threshold,
                     singlescale_threshold_value=singlescale_threshold_value,
                     dynamic_sizing=dynamic_sizing,
                     force_square=force_square,
@@ -1133,6 +1201,7 @@ if casa_enabled:
                 self,
                 chunk_num=None,
                 convergence_fracflux=0.01,
+                convergence_noise_z_threshold=None,
                 backup=True,
                 gather_chunks_into_cube=False,
                 remove_chunks=False,
@@ -1221,6 +1290,7 @@ if casa_enabled:
                             stop_at_negative=True,
                             remask_each_loop=False,
                             force_dirty_image=False,
+                            convergence_noise_z_threshold=convergence_noise_z_threshold,
                             )
 
                 if backup:
@@ -1349,6 +1419,7 @@ if casa_enabled:
                 self,
                 chunk_num=None,
                 convergence_fracflux=0.01,
+                convergence_noise_z_threshold=None,
                 gather_chunks_into_cube=False,
                 remove_chunks=False,
                 threshold_value=1.0,
@@ -1450,6 +1521,7 @@ if casa_enabled:
                         stop_at_negative=False,
                         remask_each_loop=False,
                         force_dirty_image=False,
+                        convergence_noise_z_threshold=convergence_noise_z_threshold,
                     )
 
                 if backup:
@@ -1468,7 +1540,8 @@ if casa_enabled:
             return ()
 
         @CleanCallFunctionDecorator
-        def task_complete_gather_into_cubes(self, root_name='all', remove_chunks=False):
+        def task_complete_gather_into_cubes(self, root_name='all',
+                                            remove_chunks=False, overwrite=False):
             '''
             Intended to create a final set of cubes.
             '''
@@ -1485,7 +1558,8 @@ if casa_enabled:
             for root in root_names:
 
                 self.task_gather_into_cube(root_name=root,
-                                           remove_chunks=remove_chunks)
+                                           remove_chunks=remove_chunks,
+                                           overwrite=overwrite)
 
         @CleanCallFunctionDecorator
         def task_export_to_fits(
@@ -1587,6 +1661,7 @@ if casa_enabled:
                 do_export_to_fits=True,
                 do_cleanup=True,
                 convergence_fracflux=0.01,
+                convergence_noise_z_threshold=None,
                 singlescale_threshold_value=1.0,
                 dynamic_sizing=True,
                 force_square=False,
@@ -1651,6 +1726,7 @@ if casa_enabled:
                 if do_multiscale_clean:
                     self.task_multiscale_clean(chunk_num=chunk_to_iter,
                                                convergence_fracflux=convergence_fracflux,
+                                               convergence_noise_z_threshold=convergence_noise_z_threshold,
                                                gather_chunks_into_cube=False,
                                                )
 
@@ -1670,6 +1746,7 @@ if casa_enabled:
                 if do_singlescale_clean:
                     self.task_singlescale_clean(chunk_num=chunk_to_iter,
                                                 convergence_fracflux=convergence_fracflux,
+                                                convergence_noise_z_threshold=convergence_noise_z_threshold,
                                                 threshold_value=singlescale_threshold_value,
                                                 skip_singlescale_if_mask_empty=skip_singlescale_if_mask_empty,
                                                 gather_chunks_into_cube=False)

--- a/phangsPipeline/taskSDIntImaging.py
+++ b/phangsPipeline/taskSDIntImaging.py
@@ -334,6 +334,7 @@ def sdintimaging(
         minpsffraction,
         maxpsffraction,
         interactive,
+        fullsummary,
         # (new) Mask parameters
         usemask,
         mask,
@@ -669,8 +670,10 @@ def sdintimaging(
                 deconvolvertool.updateMask()
 
                 # Get summary from iterbot
-                if type(interactive) != bool:
-                    retrec = deconvolvertool.getSummary()
+                retrec = deconvolvertool.getSummary(fullsummary);
+                retrec['nmajordone'] = imager.majorCnt
+                if calcres == True:
+                    retrec['nmajordone'] = retrec['nmajordone'] + 1  ## To be consistent with tclean. Remove, when we can change the meaning of nmajordone to exclude the initial major cycles.
 
                 # If we have a convergence_fracflux set, check here and break out if the flux change is below threshold
                 if convergence_fracflux is not None:

--- a/phangsPipelineTests/__init__.py
+++ b/phangsPipelineTests/__init__.py
@@ -10,24 +10,28 @@ from .test_handlerVis import TestingHandlerVis
 from .test_handlerVis import TestingHandlerVisInCasa
 from .test_handlerImaging import TestingHandlerImaging
 from .test_handlerImaging import TestingHandlerImagingInCasa
+from .test_noise_convergence import TestingNoiseConvergence
+from .test_noise_convergence import TestingNoiseConvergenceInCasa
+from .test_check_noise_convergence import TestCheckNoiseConvergence
+from .test_check_noise_convergence import TestingCheckNoiseConvergenceInCasa
 
 import phangsPipeline
 import unittest
 
 class TestingAllInCasa():
     """docstring for TestingHandlerKeysInCasa
-    
+
     To run all tests, run following command in CASA:
         sys.path.append('../analysis_scripts')
         sys.path.append('.')
         import phangsPipelineTests
         phangsPipelineTests.TestingAllInCasa().run()
-    
+
     """
-    
+
     def __init__(self):
         pass
-    
+
     def suite(self=None):
         testsuite = unittest.TestSuite()
         testsuite.addTest(unittest.makeSuite(TestingPipelineLogger))
@@ -36,10 +40,12 @@ class TestingAllInCasa():
         testsuite.addTest(unittest.makeSuite(TestingHandlerKeys))
         testsuite.addTest(unittest.makeSuite(TestingHandlerVis))
         testsuite.addTest(unittest.makeSuite(TestingHandlerImaging))
+        testsuite.addTest(unittest.makeSuite(TestCheckNoiseConvergence))
+        testsuite.addTest(unittest.makeSuite(TestingNoiseConvergence))
         return testsuite
-    
+
     def run(self):
-        unittest.main(defaultTest='phangsPipelineTests.TestingAllInCasa.suite', 
-                      verbosity=2, 
+        unittest.main(defaultTest='phangsPipelineTests.TestingAllInCasa.suite',
+                      verbosity=2,
                       exit=False)
 

--- a/phangsPipelineTests/minimal_key_writer.py
+++ b/phangsPipelineTests/minimal_key_writer.py
@@ -1,0 +1,355 @@
+"""
+Write a complete set of PHANGS pipeline key files for a single target,
+configuration, and spectral product.
+
+Mirrors the full directory and key-file structure of the production
+phangs-alma_keys setup (see phangs-alma_keys/master_key.txt), so that
+KeyHandler reads without warnings about missing keys or directories.
+Optional key files (singledish, cleanmask, distance, window, moment,
+derived, linmos, override, dir) are written as comment-only stubs.
+
+Pure Python — no CASA required.
+
+Usage:
+    from phangsPipelineTests.minimal_key_writer import MinimalKeyWriter
+    writer = MinimalKeyWriter(
+        key_dir='/path/to/test_keys/',
+        data_dir='/path/to/test_data/',
+        ms_root='/path/to/test_data/uvdata/',
+    )
+    master_key_path = writer.write_all(
+        target='noise_only',
+        config='C1',
+        product='co21',
+        ms_filename='noise_only.ms',
+        restfreq_GHz=230.538,
+        ra='12h00m00.0s',
+        dec='-30d00m00.0s',
+    )
+"""
+
+import os
+
+
+class MinimalKeyWriter:
+    """
+    Write a complete PHANGS key set for a single target + interferometric
+    config + line product.
+
+    Directory layout under data_dir (all created on write_all()):
+        imaging/
+        postprocess/
+        derived/
+        release/
+        singledish/
+        cleanmasks/
+        vfields/
+
+    Key files written into key_dir:
+        master_key.txt              — root configuration
+        target_definitions.txt      — target positions / velocities
+        config_definitions.txt      — array configs and spectral products
+        ms_file_key.txt             — MS locations
+        imaging_recipes.txt         — tclean recipe assignments
+        noise_only.clean            — tclean parameter file for test imaging
+        singledish_key.txt          — stub (no single-dish data)
+        cleanmask_key.txt           — stub (no clean masks)
+        distance_key.txt            — stub (no distance data)
+        window_key.txt              — stub (no velocity windows)
+        moment_key.txt              — stub (no moment definitions)
+        derived_key.txt             — stub (no derived products)
+        linearmosaic_definitions.txt — stub (no linear mosaics)
+        overrides.txt               — stub (no parameter overrides)
+        dir_key.txt                 — stub (no directory remapping)
+
+    Parameters
+    ----------
+    key_dir : str
+        Directory where key files will be written.
+    data_dir : str
+        Root directory for all pipeline output trees.
+    ms_root : str
+        Directory containing the measurement set file.
+    """
+
+    # Sub-directories of data_dir that mirror the production layout
+    _DATA_SUBDIRS = [
+        'uvdata',
+        'imaging',
+        'postprocess',
+        'derived',
+        'release',
+        'singledish',
+        'cleanmasks',
+        'vfields',
+    ]
+
+    def __init__(self, key_dir, data_dir, ms_root):
+        self.key_dir  = os.path.abspath(key_dir)
+        self.data_dir = os.path.abspath(data_dir)
+        self.ms_root  = os.path.abspath(ms_root)
+
+    def write_all(self, target, config, product, ms_filename,
+                  restfreq_GHz, ra, dec):
+        """
+        Write all key files and return the path to master_key.txt.
+
+        Parameters
+        ----------
+        target : str
+            Target name used consistently across all key files.
+        config : str
+            Interferometric configuration name (e.g. 'C1').
+        product : str
+            Spectral line product name (e.g. 'co21').
+        ms_filename : str
+            Filename of the MS relative to ms_root (e.g. 'noise_only.ms').
+        restfreq_GHz : float
+            Rest frequency of the line in GHz.
+        ra : str
+            Phase centre RA string (e.g. '12h00m00.0s').
+        dec : str
+            Phase centre Dec string (e.g. '-30d00m00.0s').
+
+        Returns
+        -------
+        str
+            Absolute path to master_key.txt.
+        """
+        os.makedirs(self.key_dir, exist_ok=True)
+        for subdir in self._DATA_SUBDIRS:
+            os.makedirs(os.path.join(self.data_dir, subdir), exist_ok=True)
+
+        self._write_master_key()
+        self._write_target_definitions(target, ra, dec)
+        self._write_config_definitions(config, product)
+        self._write_ms_file_key(target, config, ms_filename)
+        self._write_imaging_recipes(product)
+        self._write_noise_only_clean()
+
+        # Optional stub key files — empty but present so KeyHandler finds them
+        self._write_stub('singledish_key.txt',
+                         'target  product  singledish_fits_path')
+        self._write_stub('cleanmask_key.txt',
+                         'target  product  cleanmask_fits_path')
+        self._write_stub('distance_key.txt',
+                         'target,dist')
+        self._write_stub('window_key.txt',
+                         'target,window,vfield_file')
+        self._write_stub('moment_key.txt',
+                         'moment_name  keyword  value')
+        self._write_stub('derived_key.txt',
+                         'config  product  keyword  value')
+        self._write_stub('linearmosaic_definitions.txt',
+                         'mosaic_target  member_target')
+        self._write_stub('overrides.txt',
+                         'imagename  parameter  value')
+        self._write_stub('dir_key.txt',
+                         'pointing_target  galaxy_target')
+
+        return os.path.join(self.key_dir, 'master_key.txt')
+
+    # ------------------------------------------------------------------
+    # Private writers
+    # ------------------------------------------------------------------
+
+    def _write_master_key(self):
+        d = self.data_dir
+        lines = [
+            '# Auto-generated master key for pipeline tests\n',
+            '# Mirrors the structure of phangs-alma_keys/master_key.txt\n',
+            '\n',
+            'key_dir             {}/\n'.format(self.key_dir),
+            '\n',
+            'ms_root             {}/\n'.format(
+                os.path.join(d, 'uvdata')),
+            'imaging_root        {}/\n'.format(
+                os.path.join(d, 'imaging')),
+            'postprocess_root    {}/\n'.format(
+                os.path.join(d, 'postprocess')),
+            'derived_root        {}/\n'.format(
+                os.path.join(d, 'derived')),
+            'release_root        {}/\n'.format(
+                os.path.join(d, 'release')),
+            'singledish_root     {}/\n'.format(
+                os.path.join(d, 'singledish')),
+            'cleanmask_root      {}/\n'.format(
+                os.path.join(d, 'cleanmasks')),
+            'vfield_root         {}/\n'.format(
+                os.path.join(d, 'vfields')),
+            '\n',
+            'ms_key              ms_file_key.txt\n',
+            'config_key          config_definitions.txt\n',
+            'target_key          target_definitions.txt\n',
+            'imaging_key         imaging_recipes.txt\n',
+            'singledish_key      singledish_key.txt\n',
+            'cleanmask_key       cleanmask_key.txt\n',
+            'distance_key        distance_key.txt\n',
+            'window_key          window_key.txt\n',
+            'moment_key          moment_key.txt\n',
+            'derived_key         derived_key.txt\n',
+            'linmos_key          linearmosaic_definitions.txt\n',
+            'override_key        overrides.txt\n',
+            'dir_key             dir_key.txt\n',
+        ]
+        self._write_file('master_key.txt', lines)
+
+    def _write_target_definitions(self, target, ra, dec):
+        # velocity_kms=0 (vsys), width_kms=15:
+        # 15 km/s ≈ 11.5 MHz at 230.538 GHz, which fits within the 18 MHz
+        # simulated bandwidth (12 channels × 1.5 MHz) and selects ~8 channels
+        # after SPW staging — satisfying the >4-channel requirement.
+        lines = [
+            '# Auto-generated target definitions for pipeline tests\n',
+            '# Columns: target  ra  dec  velocity_kms  width_kms\n',
+            '{}\t{}\t{}\t0\t15\n'.format(target, ra, dec),
+        ]
+        self._write_file('target_definitions.txt', lines)
+
+    def _write_config_definitions(self, config, product):
+        # Both 'array_tags' and 'clean_scales_arcsec' must be present:
+        # print_configs() accesses them directly without a try/except.
+        # The array_tag must also match the array_tag column in ms_file_key.txt.
+        #
+        # line_product requires 'line_tag' (raises if missing in task_split)
+        # and 'channel_kms' (raises if missing in task_split).
+        # 'restfreq' is not a valid line_product field — the rest frequency
+        # is looked up from utilsLines via line_tag.
+        lines = [
+            '# Auto-generated config definitions for pipeline tests\n',
+            '# Columns: type  name  parameters\n',
+            "interf_config\t{config}\t{{'array_tags':['{config}'],"
+            "'clean_scales_arcsec':[0]}}\n".format(config=config),
+            "line_product\t{product}\t{{'line_tag':'{product}',"
+            "'channel_kms':2.6}}\n".format(product=product),
+        ]
+        self._write_file('config_definitions.txt', lines)
+
+    def _write_ms_file_key(self, target, config, ms_filename):
+        lines = [
+            '# Auto-generated MS file key for pipeline tests\n',
+            '# Columns: target  project  field  array_tag  obs_num  filepath\n',
+            '{}\ttest_proj\tall\t{}\t1\t{}\n'.format(
+                target, config, ms_filename),
+        ]
+        self._write_file('ms_file_key.txt', lines)
+
+    def _write_imaging_recipes(self, product):
+        lines = [
+            '# Auto-generated imaging recipes for pipeline tests\n',
+            '# Columns: config  product  stage  recipe_file\n',
+            'all\t{}\tall\tnoise_only.clean\n'.format(product),
+        ]
+        self._write_file('imaging_recipes.txt', lines)
+
+    def _write_stub(self, filename, column_header):
+        """Write a header-only (no data) stub key file."""
+        lines = [
+            '# Auto-generated stub for pipeline tests — no entries\n',
+            '# Columns: {}\n'.format(column_header),
+        ]
+        self._write_file(filename, lines)
+
+    def _write_noise_only_clean(self):
+        """
+        Write a minimal tclean parameter file for a noise-only,
+        single-pointing MS produced by simobserve.
+
+        Key differences from the production cube_mosaic.clean:
+          - datacolumn  = "data"      (simobserve creates DATA, not CORRECTED)
+          - gridder     = "standard"  (single pointing, no mosaic)
+          - usemask     = "pb"        (no external clean mask needed)
+          - imsize      = [64]        (small for fast tests)
+          - cell        = ['1.0arcsec']
+          - scales      = []          (point source only for speed)
+        """
+        lines = [
+            '# Auto-generated tclean parameter file for noise-only tests\n',
+            'vis                       =  ""\n',
+            'selectdata                =  True\n',
+            'field                     =  ""\n',
+            'spw                       =  ""\n',
+            'timerange                 =  ""\n',
+            'uvrange                   =  ""\n',
+            'antenna                   =  ""\n',
+            'scan                      =  ""\n',
+            'observation               =  ""\n',
+            'intent                    =  ""\n',
+            # simobserve creates DATA column, not CORRECTED_DATA
+            'datacolumn                =  "data"\n',
+            'imagename                 =  ""\n',
+            'imsize                    =  [64]\n',
+            "cell                      =  ['1.0arcsec']\n",
+            'phasecenter               =  ""\n',
+            'stokes                    =  "I"\n',
+            'projection                =  "SIN"\n',
+            'startmodel                =  ""\n',
+            'specmode                  =  "cube"\n',
+            'reffreq                   =  ""\n',
+            'nchan                     =  -1\n',
+            'start                     =  ""\n',
+            'width                     =  ""\n',
+            'outframe                  =  "LSRK"\n',
+            'veltype                   =  "radio"\n',
+            'restfreq                  =  []\n',
+            'interpolation             =  "linear"\n',
+            'perchanweightdensity      =  True\n',
+            # Single pointing — standard gridder, not mosaic
+            'gridder                   =  "standard"\n',
+            'facets                    =  1\n',
+            'psfphasecenter            =  ""\n',
+            'chanchunks                =  1\n',
+            'wprojplanes               =  1\n',
+            'vptable                   =  ""\n',
+            'pblimit                   =  0.2\n',
+            'normtype                  =  "flatnoise"\n',
+            'deconvolver               =  "multiscale"\n',
+            'scales                    =  []\n',
+            'nterms                    =  1\n',
+            'smallscalebias            =  0.9\n',
+            'restoration               =  True\n',
+            'restoringbeam             =  "common"\n',
+            'pbcor                     =  False\n',
+            'outlierfile               =  ""\n',
+            'weighting                 =  "briggs"\n',
+            'robust                    =  0.5\n',
+            "noise                     =  '1.0Jy'\n",
+            'npixels                   =  0\n',
+            'uvtaper                   =  []\n',
+            'niter                     =  1\n',
+            'gain                      =  0.1\n',
+            "threshold                 =  '0.0mJy/beam'\n",
+            'nsigma                    =  0.0\n',
+            'cycleniter                =  200\n',
+            'cyclefactor               =  3.0\n',
+            'minpsffraction            =  0.5\n',
+            'maxpsffraction            =  0.8\n',
+            'interactive               =  False\n',
+            # Use PB mask only — no external clean mask file required
+            'usemask                   =  "pb"\n',
+            'mask                      =  ""\n',
+            'pbmask                    =  0.2\n',
+            'sidelobethreshold         =  3.0\n',
+            'noisethreshold            =  5.0\n',
+            'lownoisethreshold         =  1.5\n',
+            'negativethreshold         =  0.0\n',
+            'smoothfactor              =  1.0\n',
+            'minbeamfrac               =  0.3\n',
+            'cutthreshold              =  0.01\n',
+            'growiterations            =  75\n',
+            'dogrowprune               =  True\n',
+            'minpercentchange          =  -1.0\n',
+            'verbose                   =  False\n',
+            'fastnoise                 =  True\n',
+            'restart                   =  True\n',
+            'savemodel                 =  "none"\n',
+            'calcres                   =  True\n',
+            'calcpsf                   =  True\n',
+            'parallel                  =  False\n',
+        ]
+        self._write_file('noise_only.clean', lines)
+
+    def _write_file(self, filename, lines):
+        filepath = os.path.join(self.key_dir, filename)
+        with open(filepath, 'w') as f:
+            f.writelines(lines)

--- a/phangsPipelineTests/noise_only_ms_factory.py
+++ b/phangsPipelineTests/noise_only_ms_factory.py
@@ -1,0 +1,268 @@
+"""
+Factory for creating a noise-only ALMA measurement set via CASA's simobserve.
+
+Intended for use in pipeline tests that need a realistic but signal-free MS.
+All CASA imports are deferred to method bodies so this module can be imported
+in a plain Python 3 environment without CASA present.
+
+Usage (inside CASA):
+    from phangsPipelineTests.noise_only_ms_factory import NoiseOnlyMSFactory
+    ms_path = NoiseOnlyMSFactory().create('/path/to/uvdata_dir/')
+    # ... run tests ...
+    NoiseOnlyMSFactory().cleanup('/path/to/uvdata_dir/')
+"""
+
+import glob
+import os
+import shutil
+
+# ---------------------------------------------------------------------------
+# Default simulation parameters
+# ---------------------------------------------------------------------------
+
+DEFAULT_PARAMS = {
+    # Sky / pointing
+    'target_name':        'noise_only',
+    'ra':                 '12h00m00.0s',
+    'dec':                '-30d00m00.0s',
+
+    # Spectral setup (CO 2-1 as representative line).
+    # Channel width must be < max_chanwidth_ghz (= restfreq * channel_kms / c
+    # = 230.538 * 2.6 / 299792 ≈ 1.997 MHz) so that find_spws_for_line
+    # accepts the SPW.  12 channels × 1.5 MHz = 18 MHz ≈ 23 km/s total
+    # bandwidth, which comfortably covers the 15 km/s test velocity window
+    # while leaving ~8 channels after SPW selection (> 4 required).
+    'restfreq_GHz':       230.538,
+    'chan_width_MHz':     1.5,
+    'nchan':              12,
+
+    # Observing
+    'integration_s':      30.0,    # per integration
+    'total_time_s':       300.0,   # total on-source time
+
+    # Noise: added per visibility per baseline per integration
+    # 'noise_jy':           0.05,
+
+    # ALMA antenna configuration bundled with CASA 6.4+.
+    # C-1 (most compact) gives fast simulations with reasonable UV coverage.
+    # Switch to 'alma.cycle10.2.cfg' for C-2 if broader UV coverage is needed.
+    'antennalist':        'alma.cycle10.1.cfg',
+
+    # Sky model image (blank, all zeros)
+    'image_size_pix':     32,
+    'pixel_size_arcsec':  1.0,
+}
+
+# Name used for the simobserve project subdirectory and the final MS file
+_PROJECT_NAME = 'noise_sim'
+_MS_FILENAME  = 'noise_only.ms'
+
+
+class NoiseOnlyMSFactory:
+    """
+    Create and optionally clean up a noise-only ALMA MS for pipeline tests.
+
+    The MS is produced by simobserve with a blank (all-zero) sky model and
+    simplenoise thermal noise. The output DATA column (not CORRECTED_DATA)
+    contains purely thermal noise — there is no astrophysical signal.
+
+    Parameters
+    ----------
+    None — all simulation parameters are passed to create().
+    """
+
+    def create(self, output_dir, params=None):
+        """
+        Generate a noise-only MS and place it at output_dir/noise_only.ms.
+
+        Parameters
+        ----------
+        output_dir : str
+            Directory where noise_only.ms will be written. Created if absent.
+        params : dict, optional
+            Override any keys in DEFAULT_PARAMS.
+
+        Returns
+        -------
+        str
+            Absolute path to the created MS (output_dir/noise_only.ms).
+        """
+        # Merge parameter overrides
+        p = dict(DEFAULT_PARAMS)
+        if params is not None:
+            p.update(params)
+
+        output_dir = os.path.abspath(output_dir)
+        os.makedirs(output_dir, exist_ok=True)
+
+        orig_dir = os.getcwd()
+
+        # simobserve writes everything relative to cwd
+        os.chdir(output_dir)
+
+        sky_fits = os.path.join(output_dir, 'blank_sky.fits')
+        self._write_blank_sky(sky_fits, p)
+
+        self._run_simobserve(sky_fits, p)
+
+        ms_dst = os.path.join(output_dir, _MS_FILENAME)
+
+        # Prefer the noisy MS (thermalnoise was requested); fall back to the
+        # noiseless MS if simobserve only produced that variant.  Use glob so
+        # the lookup is independent of the antenna-config suffix in the filename.
+        sim_dir = os.path.join(output_dir, _PROJECT_NAME)
+        noisy_matches = glob.glob(os.path.join(sim_dir, '*.noisy.ms'))
+        clean_matches = glob.glob(os.path.join(sim_dir, '*.ms'))
+        # Filter clean_matches to exclude anything already matched as noisy
+        clean_only = [m for m in clean_matches
+                      if not m.endswith('.noisy.ms')]
+
+        if noisy_matches:
+            ms_src = noisy_matches[0]
+        elif clean_only:
+            ms_src = clean_only[0]
+        else:
+            raise RuntimeError(
+                'simobserve did not produce an MS under: ' + sim_dir)
+
+        if os.path.isdir(ms_dst):
+            shutil.rmtree(ms_dst)
+        shutil.move(ms_src, ms_dst)
+
+        return os.path.join(output_dir, _MS_FILENAME)
+
+    def cleanup(self, output_dir):
+        """
+        Remove the MS previously created by create().
+
+        Parameters
+        ----------
+        output_dir : str
+            Same directory that was passed to create().
+        """
+        ms_path = os.path.join(os.path.abspath(output_dir), _MS_FILENAME)
+        if os.path.isdir(ms_path):
+            shutil.rmtree(ms_path)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _write_blank_sky(self, sky_fits_path, p):
+        """
+        Write a 3-D sky model FITS cube (RA × Dec × Freq) for simobserve.
+
+        A 3-D cube is required so that simobserve produces a multi-channel MS.
+        A 2-D image produces only a single-channel MS regardless of how
+        incenter/inwidth are set.
+
+        simobserve's simutil computes scalefactor = inbright / nanmax(image).
+        An all-zero cube causes nanmax=0 → scalefactor=nan → "WARN: model is
+        empty" and simobserve exits before writing any MS.
+
+        Fix: place a single voxel with a negligibly small value (1e-10
+        Jy/pixel) at the spatial and spectral centre.  This is ~11 orders of
+        magnitude below the thermal noise level and has no practical effect on
+        the noise-only output MS.
+        """
+        try:
+            from astropy.io import fits
+            import numpy as np
+        except ImportError:
+            import pyfits as fits  # CASA 5.x environment
+            import numpy as np
+
+        n     = p['image_size_pix']
+        nchan = p['nchan']
+        chan_width_hz = p['chan_width_MHz'] * 1e6
+        restfreq_hz  = p['restfreq_GHz'] * 1e9
+
+        # numpy array shape (nchan, n, n) → FITS axes NAXIS1=n, NAXIS2=n, NAXIS3=nchan
+        data = np.zeros((nchan, n, n), dtype=np.float32)
+
+        # Non-zero seed voxel at spatial and spectral centre
+        cx, cy = n // 2, n // 2
+        data[nchan // 2, cy, cx] = 1e-10
+
+        ra_deg  = self._ra_str_to_deg(p['ra'])
+        dec_deg = self._dec_str_to_deg(p['dec'])
+
+        hdr = fits.Header()
+        hdr['SIMPLE']  = True
+        hdr['BITPIX']  = -32
+        hdr['NAXIS']   = 3
+        hdr['NAXIS1']  = n
+        hdr['NAXIS2']  = n
+        hdr['NAXIS3']  = nchan
+        # RA axis
+        hdr['CTYPE1']  = 'RA---SIN'
+        hdr['CRVAL1']  = ra_deg
+        hdr['CRPIX1']  = n / 2.0
+        hdr['CDELT1']  = -p['pixel_size_arcsec'] / 3600.0
+        hdr['CUNIT1']  = 'deg'
+        # Dec axis
+        hdr['CTYPE2']  = 'DEC--SIN'
+        hdr['CRVAL2']  = dec_deg
+        hdr['CRPIX2']  = n / 2.0
+        hdr['CDELT2']  =  p['pixel_size_arcsec'] / 3600.0
+        hdr['CUNIT2']  = 'deg'
+        # Frequency axis — centre channel at restfreq, width = chan_width_MHz
+        hdr['CTYPE3']  = 'FREQ'
+        hdr['CRVAL3']  = restfreq_hz
+        hdr['CRPIX3']  = (nchan + 1) / 2.0   # 1-indexed centre channel
+        hdr['CDELT3']  = chan_width_hz
+        hdr['CUNIT3']  = 'Hz'
+        hdr['RESTFRQ'] = restfreq_hz
+        hdr['BUNIT']   = 'Jy/pixel'
+        hdr['EQUINOX'] = 2000.0
+
+        hdu = fits.PrimaryHDU(data=data, header=hdr)
+        hdu.writeto(sky_fits_path, overwrite=True)
+
+    def _run_simobserve(self, sky_fits_path, p):
+        """Call CASA's simobserve to produce the noisy MS.
+
+        incenter = centre frequency of the central channel.
+        inwidth  = width of each individual channel (NOT total bandwidth).
+        The number of output channels is driven by the NAXIS3 of the 3-D
+        sky model cube; incenter/inwidth locate that cube in frequency.
+        """
+        from casatasks import simobserve
+
+        direction = 'J2000 {ra} {dec}'.format(ra=p['ra'], dec=p['dec'])
+
+        simobserve(
+            project        = _PROJECT_NAME,
+            skymodel       = sky_fits_path,
+            indirection    = direction,
+            incell         = '{:.4f}arcsec'.format(p['pixel_size_arcsec']),
+            incenter       = '{:.6f}GHz'.format(p['restfreq_GHz']),
+            inwidth        = '{:.4f}MHz'.format(p['chan_width_MHz']),
+            setpointings   = True,
+            integration    = '{:.1f}s'.format(p['integration_s']),
+            totaltime      = '{:.1f}s'.format(p['total_time_s']),
+            antennalist    = p['antennalist'],
+            thermalnoise   = 'tsys-manual',
+            overwrite      = True,
+        )
+
+    @staticmethod
+    def _ra_str_to_deg(ra_str):
+        """Convert 'HHhMMmSS.Ss' to decimal degrees."""
+        ra_str = ra_str.strip()
+        # Support 'HHhMMmSS.Ss' or 'HH:MM:SS.S'
+        ra_str = ra_str.replace('h', ':').replace('m', ':').replace('s', '')
+        parts = ra_str.split(':')
+        h, m, s = float(parts[0]), float(parts[1]), float(parts[2])
+        return (h + m / 60.0 + s / 3600.0) * 15.0
+
+    @staticmethod
+    def _dec_str_to_deg(dec_str):
+        """Convert '+/-DDdMMmSS.Ss' to decimal degrees."""
+        dec_str = dec_str.strip()
+        dec_str = dec_str.replace('d', ':').replace('m', ':').replace('s', '')
+        sign = -1.0 if dec_str.startswith('-') else 1.0
+        dec_str = dec_str.lstrip('+-')
+        parts = dec_str.split(':')
+        d, m, s = float(parts[0]), float(parts[1]), float(parts[2])
+        return sign * (d + m / 60.0 + s / 3600.0)

--- a/phangsPipelineTests/test_check_noise_convergence.py
+++ b/phangsPipelineTests/test_check_noise_convergence.py
@@ -1,0 +1,505 @@
+"""
+Unit tests for check_noise_convergence() in casaImagingRoutines.
+
+These tests are fully self-contained: no CASA, no MS, no key files.
+Mock tclean fullsummary dictionaries are constructed inline.
+
+How to run:
+    # Plain Python 3 (no CASA required):
+    cd phangs_imaging_scripts
+    python -m pytest phangsPipelineTests/test_check_noise_convergence.py -v
+
+    # Inside CASA:
+    sys.path.append('.')
+    import phangsPipelineTests
+    phangsPipelineTests.TestingCheckNoiseConvergenceInCasa().run()
+"""
+
+import sys
+import unittest
+import math
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Import check_noise_convergence without triggering CASA-dependent imports.
+# casaImagingRoutines imports analysisUtils and casaStuff at module level;
+# we stub those out before importing so the module loads in plain Python 3.
+# ---------------------------------------------------------------------------
+
+def _import_check_noise_convergence():
+    """
+    Return check_noise_convergence with CASA stubs in place.
+
+    casaImagingRoutines is loaded directly from its file via
+    importlib.util.spec_from_file_location, bypassing phangsPipeline/__init__.py
+    which would pull in the full package and its CASA-dependent imports.
+    """
+    import types
+    import importlib.util
+    import os
+
+    # Stub every CASA/pipeline module that casaImagingRoutines imports at the
+    # top level.  Only add stubs for names not already present (avoids clobbering
+    # real modules when running inside CASA).
+    stubs_needed = {
+        'analysisUtils':                   {},
+        'casaStuff':                       {},
+        'pyfits':                          {},
+        'phangsPipeline.casaStuff':        {},
+        'phangsPipeline.casaMaskingRoutines': {},
+        'phangsPipeline.pipelineVersion':  {'version': '0.0.0-test',
+                                            'tableversion': '0'},
+        'phangsPipeline.clean_call':       {'CleanCall': object},
+    }
+    for mod_name, attrs in stubs_needed.items():
+        if mod_name not in sys.modules:
+            stub = types.ModuleType(mod_name)
+            for attr, val in attrs.items():
+                setattr(stub, attr, val)
+            sys.modules[mod_name] = stub
+
+    # Load casaImagingRoutines directly from its file so phangsPipeline's
+    # __init__.py (which imports the full package) is never executed.
+    mod_name = 'phangsPipeline.casaImagingRoutines'
+    if mod_name in sys.modules:
+        mod = sys.modules[mod_name]
+    else:
+        here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        src  = os.path.join(here, 'phangsPipeline', 'casaImagingRoutines.py')
+        spec = importlib.util.spec_from_file_location(mod_name, src)
+        mod  = importlib.util.module_from_spec(spec)
+        sys.modules[mod_name] = mod
+        spec.loader.exec_module(mod)
+
+    return mod.check_noise_convergence
+
+
+check_noise_convergence = _import_check_noise_convergence()
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a minimal fullsummary dict
+# ---------------------------------------------------------------------------
+
+def _make_summary(cycles, field='0', chan='0', pol='0'):
+    """
+    Build a mock tclean fullsummary dict.
+
+    Parameters
+    ----------
+    cycles : list of (iter_done, model_flux, start_model_flux)
+        One tuple per major cycle.  Values are per-cycle scalars.
+    field, chan, pol : str
+        Keys used for the nested summaryminor structure.
+
+    Returns
+    -------
+    dict  matching the structure of tclean(fullsummary=True)
+    """
+    iter_done    = np.array([c[0] for c in cycles])
+    model_flux   = np.array([c[1] for c in cycles])
+    start_flux   = np.array([c[2] for c in cycles])
+
+    return {
+        'summaryminor': {
+            field: {
+                chan: {
+                    pol: {
+                        'iterDone':       iter_done,
+                        'modelFlux':      model_flux,
+                        'startModelFlux': start_flux,
+                    }
+                }
+            }
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestCheckNoiseConvergence(unittest.TestCase):
+
+    # ------------------------------------------------------------------
+    # Guard-rail / edge cases
+    # ------------------------------------------------------------------
+
+    def test_none_summary_returns_none(self):
+        self.assertIsNone(check_noise_convergence(None, noise=0.01, gain=0.1))
+
+    def test_non_dict_summary_returns_none(self):
+        self.assertIsNone(check_noise_convergence("not a dict", noise=0.01, gain=0.1))
+
+    def test_missing_summaryminor_key_returns_none(self):
+        self.assertIsNone(check_noise_convergence({}, noise=0.01, gain=0.1))
+
+    def test_empty_summaryminor_returns_converged_zero(self):
+        result = check_noise_convergence(
+            {'summaryminor': {}}, noise=0.01, gain=0.1)
+        self.assertIsNotNone(result)
+        self.assertEqual(result['N_components'], 0)
+        self.assertEqual(result['z_score'], 0.0)
+        self.assertTrue(result['converged'])
+
+    def test_zero_iter_done_returns_converged_zero(self):
+        summary = _make_summary([(0, 0.0, 0.0)])
+        result = check_noise_convergence(summary, noise=0.01, gain=0.1)
+        self.assertIsNotNone(result)
+        self.assertEqual(result['N_components'], 0)
+        self.assertTrue(result['converged'])
+
+    def test_missing_keys_in_data_gracefully_skipped(self):
+        # Data dict is missing 'iterDone' — should return zero-component result
+        summary = {
+            'summaryminor': {
+                '0': {'0': {'0': {'modelFlux': np.array([0.1])}}}
+            }
+        }
+        result = check_noise_convergence(summary, noise=0.01, gain=0.1)
+        self.assertIsNotNone(result)
+        self.assertEqual(result['N_components'], 0)
+
+    # ------------------------------------------------------------------
+    # Noise-only case: z-score should be near zero
+    # ------------------------------------------------------------------
+
+    def test_noise_only_z_score_near_zero(self):
+        """
+        Simulate a tclean run on pure noise.  The flux increment per cycle
+        is drawn from the expected noise distribution: each component adds
+        ~gain*noise, so the total flux increment over N components should
+        have |z| << 2.
+
+        We use a deterministic case: N=100 components, flux_sum exactly 0
+        (equal positive and negative noise components cancel).
+        """
+        noise, gain, N = 0.01, 0.1, 100
+        summary = _make_summary([
+            (N, 0.0, 0.0)  # flux_sum = modelFlux - startModelFlux = 0
+        ])
+        result = check_noise_convergence(
+            summary, noise=noise, gain=gain,
+            last_n_cycles=1, z_threshold=2.0)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result['N_components'], N)
+        self.assertAlmostEqual(result['flux_sum'], 0.0)
+        self.assertAlmostEqual(
+            result['std_expected'], math.sqrt(N) * gain * noise, places=10)
+        self.assertAlmostEqual(result['z_score'], 0.0, places=10)
+        self.assertTrue(result['converged'])
+
+    def test_noise_only_small_positive_flux_still_converges(self):
+        """
+        A small flux increment (well within 1-sigma) should still converge.
+        std_expected = sqrt(100) * 0.1 * 0.01 = 0.01
+        flux_sum = 0.005  →  z = 0.5  →  converged
+        """
+        noise, gain, N = 0.01, 0.1, 100
+        std = math.sqrt(N) * gain * noise   # 0.01
+        flux_sum = 0.5 * std                # 0.005, z=0.5
+        summary = _make_summary([(N, flux_sum, 0.0)])
+        result = check_noise_convergence(
+            summary, noise=noise, gain=gain,
+            last_n_cycles=1, z_threshold=2.0)
+
+        self.assertAlmostEqual(result['z_score'], 0.5, places=8)
+        self.assertTrue(result['converged'])
+
+    # ------------------------------------------------------------------
+    # Signal case: z-score should be large, not converged
+    # ------------------------------------------------------------------
+
+    def test_signal_present_z_score_large(self):
+        """
+        A systematic flux increment of 10*std should give z~10 and not converge.
+        std_expected = sqrt(200) * 0.1 * 0.01 ≈ 0.01414
+        flux_sum = 10 * std ≈ 0.1414
+        """
+        noise, gain, N = 0.01, 0.1, 200
+        std = math.sqrt(N) * gain * noise
+        flux_sum = 10.0 * std
+        summary = _make_summary([(N, flux_sum, 0.0)])
+        result = check_noise_convergence(
+            summary, noise=noise, gain=gain,
+            last_n_cycles=1, z_threshold=2.0)
+
+        self.assertAlmostEqual(result['z_score'], 10.0, places=6)
+        self.assertFalse(result['converged'])
+
+    def test_negative_signal_not_converged(self):
+        """
+        Negative systematic flux (|z| >> threshold) should not converge.
+        """
+        noise, gain, N = 0.01, 0.1, 100
+        std = math.sqrt(N) * gain * noise
+        flux_sum = -5.0 * std     # z = -5
+        summary = _make_summary([(N, flux_sum, 0.0)])
+        result = check_noise_convergence(
+            summary, noise=noise, gain=gain,
+            last_n_cycles=1, z_threshold=2.0)
+
+        self.assertAlmostEqual(result['z_score'], -5.0, places=6)
+        self.assertFalse(result['converged'])
+
+    # ------------------------------------------------------------------
+    # Windowing: last_n_cycles
+    # ------------------------------------------------------------------
+
+    def test_window_uses_only_last_cycles(self):
+        """
+        First 3 cycles have large signal (z>>2), last 2 are noise-consistent.
+        With last_n_cycles=2 the test should pass; with last_n_cycles=5 fail.
+        """
+        noise, gain = 0.01, 0.1
+
+        # 5 cycles: first 3 have 5*std flux each, last 2 have 0 flux
+        std_per_100 = math.sqrt(100) * gain * noise  # 0.01
+        signal_flux = 5.0 * std_per_100
+
+        cycles = [
+            (100, signal_flux, 0.0),   # cycle 0 — signal
+            (100, signal_flux, 0.0),   # cycle 1 — signal
+            (100, signal_flux, 0.0),   # cycle 2 — signal
+            (100, 0.0,         0.0),   # cycle 3 — noise
+            (100, 0.0,         0.0),   # cycle 4 — noise
+        ]
+        summary = _make_summary(cycles)
+
+        result_window2 = check_noise_convergence(
+            summary, noise=noise, gain=gain,
+            last_n_cycles=2, z_threshold=2.0)
+        result_window5 = check_noise_convergence(
+            summary, noise=noise, gain=gain,
+            last_n_cycles=5, z_threshold=2.0)
+
+        # Last 2 cycles: flux_sum=0, N=200 → z=0 → converged
+        self.assertAlmostEqual(result_window2['z_score'], 0.0, places=8)
+        self.assertTrue(result_window2['converged'])
+
+        # All 5 cycles: flux_sum=3*signal_flux, N=500 → z>>2 → not converged
+        self.assertGreater(abs(result_window5['z_score']), 2.0)
+        self.assertFalse(result_window5['converged'])
+
+    def test_window_larger_than_ncycles_uses_all(self):
+        """
+        Requesting more cycles than exist should use all available cycles
+        without error.
+        """
+        noise, gain, N = 0.01, 0.1, 50
+        summary = _make_summary([(N, 0.0, 0.0), (N, 0.0, 0.0)])
+        # last_n_cycles=10 but only 2 cycles exist
+        result = check_noise_convergence(
+            summary, noise=noise, gain=gain,
+            last_n_cycles=10, z_threshold=2.0)
+        self.assertEqual(result['N_components'], 2 * N)
+
+    # ------------------------------------------------------------------
+    # Multi-field / multi-channel accumulation
+    # ------------------------------------------------------------------
+
+    def test_multi_field_accumulation(self):
+        """
+        Two fields, each with 100 components and zero flux increment.
+        Total N_components should be 200 and z_score should be 0.
+        """
+        noise, gain, N = 0.01, 0.1, 100
+        summary = {
+            'summaryminor': {
+                '0': {'0': {'0': {
+                    'iterDone':       np.array([N]),
+                    'modelFlux':      np.array([0.0]),
+                    'startModelFlux': np.array([0.0]),
+                }}},
+                '1': {'0': {'0': {
+                    'iterDone':       np.array([N]),
+                    'modelFlux':      np.array([0.0]),
+                    'startModelFlux': np.array([0.0]),
+                }}},
+            }
+        }
+        result = check_noise_convergence(
+            summary, noise=noise, gain=gain,
+            last_n_cycles=1, z_threshold=2.0)
+
+        self.assertEqual(result['N_components'], 2 * N)
+        self.assertAlmostEqual(result['z_score'], 0.0, places=10)
+
+    def test_multi_channel_accumulation(self):
+        """
+        One field, two channels.  Channel 0 has signal (z>>2 alone),
+        channel 1 has equal and opposite flux so that the combined z is 0.
+        """
+        noise, gain, N = 0.01, 0.1, 100
+        std = math.sqrt(N) * gain * noise
+        flux = 5.0 * std  # would give z=5 if alone
+
+        summary = {
+            'summaryminor': {
+                '0': {
+                    '0': {'0': {
+                        'iterDone':       np.array([N]),
+                        'modelFlux':      np.array([flux]),
+                        'startModelFlux': np.array([0.0]),
+                    }},
+                    '1': {'0': {
+                        'iterDone':       np.array([N]),
+                        'modelFlux':      np.array([-flux]),
+                        'startModelFlux': np.array([0.0]),
+                    }},
+                }
+            }
+        }
+        result = check_noise_convergence(
+            summary, noise=noise, gain=gain,
+            last_n_cycles=1, z_threshold=2.0)
+
+        self.assertEqual(result['N_components'], 2 * N)
+        self.assertAlmostEqual(result['flux_sum'], 0.0, places=10)
+        self.assertAlmostEqual(result['z_score'], 0.0, places=8)
+
+    # ------------------------------------------------------------------
+    # z_threshold boundary
+    # ------------------------------------------------------------------
+
+    def test_z_exactly_at_threshold_not_converged(self):
+        """
+        |z| == threshold should NOT be declared converged (strict <).
+        """
+        noise, gain, N = 0.01, 0.1, 100
+        std = math.sqrt(N) * gain * noise
+        flux_sum = 2.0 * std   # z exactly = 2.0
+        summary = _make_summary([(N, flux_sum, 0.0)])
+        result = check_noise_convergence(
+            summary, noise=noise, gain=gain,
+            last_n_cycles=1, z_threshold=2.0)
+
+        self.assertAlmostEqual(result['z_score'], 2.0, places=8)
+        self.assertFalse(result['converged'])   # not strictly < 2.0
+
+    def test_z_just_below_threshold_converges(self):
+        noise, gain, N = 0.01, 0.1, 100
+        std = math.sqrt(N) * gain * noise
+        flux_sum = 1.99 * std
+        summary = _make_summary([(N, flux_sum, 0.0)])
+        result = check_noise_convergence(
+            summary, noise=noise, gain=gain,
+            last_n_cycles=1, z_threshold=2.0)
+
+        self.assertLess(result['z_score'], 2.0)
+        self.assertTrue(result['converged'])
+
+    # ------------------------------------------------------------------
+    # std_expected formula
+    # ------------------------------------------------------------------
+
+    def test_std_expected_formula(self):
+        """
+        std_expected = sqrt(N) * |gain| * noise
+        Verify for several (N, gain, noise) combinations.
+        """
+        cases = [
+            (100,  0.1,  0.01),
+            (500,  0.1,  0.005),
+            (50,   0.05, 0.02),
+            (1000, 0.1,  0.001),
+        ]
+        for N, gain, noise in cases:
+            summary = _make_summary([(N, 0.0, 0.0)])
+            result = check_noise_convergence(
+                summary, noise=noise, gain=gain, last_n_cycles=1)
+            expected_std = math.sqrt(N) * abs(gain) * noise
+            self.assertAlmostEqual(
+                result['std_expected'], expected_std, places=12,
+                msg='std_expected mismatch for N={}, gain={}, noise={}'.format(
+                    N, gain, noise))
+
+    # ------------------------------------------------------------------
+    # n_pix / extreme-value correction
+    # ------------------------------------------------------------------
+
+    def test_extreme_value_std_formula(self):
+        """
+        With n_pix provided, std_expected = sqrt(N)*gain*noise*sqrt(2*ln(2*n_pix)).
+        """
+        N, gain, noise, n_pix = 100, 0.1, 0.01, 4096
+        summary = _make_summary([(N, 0.0, 0.0)])
+        result = check_noise_convergence(
+            summary, noise=noise, gain=gain, last_n_cycles=1, n_pix=n_pix)
+        expected_std = (math.sqrt(N) * gain * noise
+                        * math.sqrt(2.0 * math.log(2.0 * n_pix)))
+        self.assertAlmostEqual(result['std_expected'], expected_std, places=10)
+
+    def test_extreme_value_noise_only_z_near_zero(self):
+        """S=0 with n_pix → z=0 → converged."""
+        summary = _make_summary([(100, 0.0, 0.0)])
+        result = check_noise_convergence(
+            summary, noise=0.01, gain=0.1,
+            last_n_cycles=1, n_pix=4096, z_threshold=2.0)
+        self.assertAlmostEqual(result['z_score'], 0.0, places=8)
+        self.assertTrue(result['converged'])
+
+    def test_extreme_value_signal_not_converged(self):
+        """flux_sum = 10*std → z=10 → not converged."""
+        N, gain, noise, n_pix = 100, 0.1, 0.01, 4096
+        std = (math.sqrt(N) * gain * noise
+               * math.sqrt(2.0 * math.log(2.0 * n_pix)))
+        flux_sum = 10.0 * std
+        summary = _make_summary([(N, flux_sum, 0.0)])
+        result = check_noise_convergence(
+            summary, noise=noise, gain=gain,
+            last_n_cycles=1, n_pix=n_pix, z_threshold=2.0)
+        self.assertAlmostEqual(result['z_score'], 10.0, places=6)
+        self.assertFalse(result['converged'])
+
+    def test_n_pix_none_uses_naive_fallback(self):
+        """n_pix=None → old formula std = sqrt(N)*gain*noise."""
+        N, gain, noise = 100, 0.1, 0.01
+        summary = _make_summary([(N, 0.0, 0.0)])
+        result = check_noise_convergence(
+            summary, noise=noise, gain=gain, last_n_cycles=1, n_pix=None)
+        self.assertAlmostEqual(
+            result['std_expected'], math.sqrt(N) * gain * noise, places=10)
+
+    def test_n_pix_1_uses_naive_fallback(self):
+        """n_pix=1 (≤ 1 guard) → old formula."""
+        summary = _make_summary([(100, 0.0, 0.0)])
+        result = check_noise_convergence(
+            summary, noise=0.01, gain=0.1, last_n_cycles=1, n_pix=1)
+        self.assertAlmostEqual(
+            result['std_expected'], math.sqrt(100) * 0.1 * 0.01, places=10)
+
+
+# ---------------------------------------------------------------------------
+# CASA wrapper
+# ---------------------------------------------------------------------------
+
+class TestingCheckNoiseConvergenceInCasa:
+    """
+    Wrapper to run TestingCheckNoiseConvergence inside CASA.
+
+    Usage:
+        import phangsPipelineTests
+        phangsPipelineTests.TestingCheckNoiseConvergenceInCasa().run()
+    """
+
+    def __init__(self):
+        pass
+
+    def suite(self=None):
+        testsuite = unittest.TestSuite()
+        testsuite.addTest(unittest.makeSuite(TestCheckNoiseConvergence))
+        return testsuite
+
+    def run(self):
+        unittest.main(
+            defaultTest=(
+                'phangsPipelineTests'
+                '.TestingCheckNoiseConvergenceInCasa.suite'),
+            verbosity=2,
+            exit=False)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/phangsPipelineTests/test_noise_convergence.py
+++ b/phangsPipelineTests/test_noise_convergence.py
@@ -1,0 +1,348 @@
+"""
+Integration test for the noise-convergence stopping criterion in clean_loop().
+
+Tests that check_noise_convergence() correctly identifies imaging runs that
+are cleaning pure noise (z-score near zero) versus runs where the statistic
+is disabled (z-score column shows N/A).
+
+How to run this test inside CASA:
+
+    sys.path.append('../analysis_scripts')
+    sys.path.append('.')
+    import phangsPipeline
+    import phangsPipelineTests
+    phangsPipelineTests.TestingNoiseConvergenceInCasa().run()
+
+What is tested:
+
+    1. test_noise_z_score_computed_and_low
+       Runs multiscale clean on a noise-only MS with
+       convergence_noise_z_threshold=2.0 and convergence_fracflux=None.
+       Asserts that the noise_z_score column in the record file contains
+       numeric values and that the final z-score is < 2.0.
+
+    2. test_noise_z_score_disabled
+       Same setup but convergence_noise_z_threshold=None.
+       Asserts that every noise_z_score entry in the record file is 'N/A'.
+
+Setup strategy:
+
+    setUpClass() runs once for the whole test class:
+      - creates the noise-only MS via simobserve
+      - writes minimal pipeline key files
+      - runs loop_stage_uvdata (HandlerVis) to stage the MS into the imaging tree
+      - makes one dirty image so each test can revert to it cheaply
+
+    Each test method only calls loop_imaging with
+      do_dirty_image=False, do_revert_to_dirty=True, do_multiscale_clean=True
+    so the expensive simobserve and staging steps are not repeated.
+"""
+
+import os
+import sys
+import glob
+import unittest
+
+from .noise_only_ms_factory import NoiseOnlyMSFactory
+from .minimal_key_writer import MinimalKeyWriter
+
+# ---------------------------------------------------------------------------
+# Test configuration
+# ---------------------------------------------------------------------------
+
+_TARGET  = 'noise_only'
+_CONFIG  = 'C1'
+_PRODUCT = 'co21'
+_RA      = '12h00m00.0s'
+_DEC     = '-30d00m00.0s'
+_RESTFREQ_GHZ = 230.538
+
+# ---------------------------------------------------------------------------
+# Record file parsing helpers
+# ---------------------------------------------------------------------------
+
+def _read_record_file(record_file):
+    """
+    Return list of data rows from a clean_loop record file, each row as a
+    list of stripped strings.  Comment lines (starting with #) are skipped.
+    """
+    rows = []
+    with open(record_file, 'r') as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            rows.append([x.strip() for x in line.split(',')])
+    return rows
+
+
+def _parse_z_scores_raw(record_file):
+    """
+    Return list of raw noise_z_score strings from the record file.
+
+    The first non-comment line is the column header; subsequent lines are
+    data.  The noise_z_score column is the last column.
+    """
+    rows = _read_record_file(record_file)
+    if len(rows) < 2:
+        return []
+    # rows[0] is the header, rows[1:] are data rows
+    return [row[-1] for row in rows[1:]]
+
+
+def _parse_z_scores(record_file):
+    """
+    Return list of noise_z_score values as floats, skipping any 'N/A' entries.
+    """
+    raw = _parse_z_scores_raw(record_file)
+    result = []
+    for val in raw:
+        try:
+            result.append(float(val))
+        except ValueError:
+            pass
+    return result
+
+
+def _find_record_file(imaging_dir, stage='multiscale'):
+    """
+    Locate the clean_loop record file for the given stage under imaging_dir.
+    Returns None if not found.
+    """
+    pattern = os.path.join(imaging_dir, '**',
+                           '*_{}_record.txt'.format(stage))
+    matches = glob.glob(pattern, recursive=True)
+    if matches:
+        return matches[0]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Test class
+# ---------------------------------------------------------------------------
+
+class TestingNoiseConvergence(unittest.TestCase):
+    """
+    Integration tests for the noise-convergence stopping criterion.
+
+    setUpClass() runs once: creates the noise-only MS, writes key files,
+    stages the UV data via HandlerVis, and makes a dirty image.
+
+    Individual test methods revert to the dirty image and run multiscale
+    clean with different convergence settings.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        One-time setup for the entire test class:
+          1. Create noise-only MS via simobserve.
+          2. Write minimal pipeline key files.
+          3. Stage the MS into the imaging tree via loop_stage_uvdata.
+          4. Make one dirty image so tests can cheaply revert to it.
+        """
+        import phangsPipeline
+        from phangsPipeline import handlerKeys as kh
+        from phangsPipeline import handlerVis as uvh
+        from phangsPipeline import handlerImaging as imh
+
+        cls.current_dir  = os.getcwd()
+        cls.module_dir   = os.path.dirname(
+            os.path.abspath(phangsPipeline.__path__[0]))
+        cls.working_dir  = os.path.join(cls.module_dir, 'phangsPipelineTests')
+        cls.test_data_dir = os.path.join(cls.working_dir,
+                                         'test_data', 'noise_only')
+        cls.test_keys_dir = os.path.join(cls.working_dir,
+                                         'test_keys', 'noise_only')
+        cls.ms_root      = os.path.join(cls.test_data_dir, 'uvdata')
+        cls.imaging_dir  = os.path.join(cls.test_data_dir, 'imaging')
+
+        os.chdir(cls.working_dir)
+
+        # Wipe any artefacts left by a previous run so each run starts clean.
+        import shutil
+        for d in [cls.test_data_dir, cls.test_keys_dir]:
+            if os.path.isdir(d):
+                shutil.rmtree(d)
+
+        for d in [cls.test_data_dir, cls.test_keys_dir,
+                  cls.ms_root, cls.imaging_dir]:
+            os.makedirs(d, exist_ok=True)
+
+        # 1. Build the noise-only MS
+        factory = NoiseOnlyMSFactory()
+        cls.ms_path = factory.create(cls.ms_root)
+
+        # 2. Write pipeline key files
+        writer = MinimalKeyWriter(
+            key_dir=cls.test_keys_dir,
+            data_dir=cls.test_data_dir,
+            ms_root=cls.ms_root,
+        )
+        cls.master_key = writer.write_all(
+            target=_TARGET,
+            config=_CONFIG,
+            product=_PRODUCT,
+            ms_filename='noise_only.ms',
+            restfreq_GHz=_RESTFREQ_GHZ,
+            ra=_RA,
+            dec=_DEC,
+        )
+
+        # 3. Stage the UV data via HandlerVis.
+        #    The simulated MS uses 1.5 MHz channels (< max_chanwidth ≈ 2 MHz
+        #    from channel_kms=2.6) and 12 channels (18 MHz total bandwidth),
+        #    which covers the 15 km/s target velocity window.
+        os.chdir(cls.working_dir)
+        this_kh = kh.KeyHandler(master_key=cls.master_key)
+        this_uvh = uvh.VisHandler(key_handler=this_kh)
+        this_uvh.set_targets(only=[_TARGET])
+        this_uvh.set_interf_configs(only=[_CONFIG])
+        this_uvh.set_line_products(only=[_PRODUCT])
+        this_uvh.loop_stage_uvdata(do_all=True)
+
+    def setUp(self):
+        os.chdir(self.working_dir)
+
+    def tearDown(self):
+        os.chdir(self.current_dir)
+
+    # Optional post-run cleanup — disabled by default so generated files
+    # can be inspected after a run.  Uncomment to clean up automatically.
+    @classmethod
+    def tearDownClass(cls):
+        import shutil
+        os.chdir(cls.current_dir)
+        for d in [cls.test_data_dir, cls.test_keys_dir]:
+            if os.path.isdir(d):
+                shutil.rmtree(d)
+
+    # ------------------------------------------------------------------
+    # Test methods
+    # ------------------------------------------------------------------
+
+    def test_noise_z_score_computed_and_low(self):
+        """
+        Run multiscale clean on noise-only data with the noise convergence
+        criterion enabled.  Verify that:
+          - the noise_z_score column contains numeric values (not N/A), and
+          - the final z-score is < 2.0, consistent with noise-only components.
+        """
+        from phangsPipeline import handlerKeys as kh
+        from phangsPipeline import handlerImaging as imh
+
+        this_kh = kh.KeyHandler(master_key=self.master_key)
+        this_imh = imh.ImagingHandler(key_handler=this_kh)
+        this_imh.set_targets(only=[_TARGET])
+        this_imh.set_interf_configs(only=[_CONFIG])
+        this_imh.set_line_products(only=[_PRODUCT])
+
+        this_imh.loop_imaging(
+            do_dirty_image=True,
+            do_revert_to_dirty=True,
+            do_read_clean_mask=False,
+            do_multiscale_clean=True,
+            do_revert_to_multiscale=False,
+            do_singlescale_mask=False,
+            do_singlescale_clean=False,
+            do_revert_to_singlescale=False,
+            do_export_to_fits=False,
+            # Disable flux-change criterion so the noise check is the
+            # primary convergence mechanism
+            convergence_fracflux=None,
+            convergence_noise_z_threshold=5.0,
+            overwrite=True,
+        )
+
+        record_file = _find_record_file(self.imaging_dir, stage='multiscale')
+        self.assertIsNotNone(
+            record_file,
+            'Could not find multiscale_record.txt under ' + self.imaging_dir)
+
+        z_scores = _parse_z_scores(record_file)
+        self.assertGreater(
+            len(z_scores), 0,
+            'No numeric z-scores found in record file: ' + record_file)
+
+        final_z = z_scores[-1]
+        self.assertLess(
+            final_z, 2.0,
+            'Final noise z-score {:.3f} >= 2.0 for noise-only data'.format(
+                final_z))
+
+    def test_noise_z_score_disabled(self):
+        """
+        Run multiscale clean with convergence_noise_z_threshold=None.
+        Verify that every noise_z_score entry in the record file is 'N/A'.
+        """
+        from phangsPipeline import handlerKeys as kh
+        from phangsPipeline import handlerImaging as imh
+
+        this_kh = kh.KeyHandler(master_key=self.master_key)
+        this_imh = imh.ImagingHandler(key_handler=this_kh)
+        this_imh.set_targets(only=[_TARGET])
+        this_imh.set_interf_configs(only=[_CONFIG])
+        this_imh.set_line_products(only=[_PRODUCT])
+
+        this_imh.loop_imaging(
+            do_dirty_image=False,
+            do_revert_to_dirty=True,
+            do_read_clean_mask=False,
+            do_multiscale_clean=True,
+            do_revert_to_multiscale=False,
+            do_singlescale_mask=False,
+            do_singlescale_clean=False,
+            do_revert_to_singlescale=False,
+            do_export_to_fits=False,
+            convergence_fracflux=0.01,
+            convergence_noise_z_threshold=None,
+            overwrite=True,
+        )
+
+        record_file = _find_record_file(self.imaging_dir, stage='multiscale')
+        self.assertIsNotNone(
+            record_file,
+            'Could not find multiscale_record.txt under ' + self.imaging_dir)
+
+        raw_z = _parse_z_scores_raw(record_file)
+        self.assertGreater(
+            len(raw_z), 0,
+            'No z-score entries found in record file: ' + record_file)
+
+        non_na = [v for v in raw_z if v != 'N/A']
+        self.assertEqual(
+            len(non_na), 0,
+            'Expected all N/A when noise threshold disabled, '
+            'but found numeric values: ' + str(non_na))
+
+
+# ---------------------------------------------------------------------------
+# CASA wrapper (mirrors TestingHandlerImagingInCasa pattern)
+# ---------------------------------------------------------------------------
+
+class TestingNoiseConvergenceInCasa:
+    """
+    Wrapper to run TestingNoiseConvergence inside CASA's Python environment.
+
+    Usage:
+        import phangsPipelineTests
+        phangsPipelineTests.TestingNoiseConvergenceInCasa().run()
+    """
+
+    def __init__(self):
+        pass
+
+    def suite(self=None):
+        testsuite = unittest.TestSuite()
+        testsuite.addTest(unittest.makeSuite(TestingNoiseConvergence))
+        return testsuite
+
+    def run(self):
+        unittest.main(
+            defaultTest='phangsPipelineTests.TestingNoiseConvergenceInCasa.suite',
+            verbosity=2,
+            exit=False)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add additional convergence test based on sampling from the noise distribution.

The main thing this PR adds is `check_noise_convergence`. It's an optional, additional, convergence check that handles cases where a few clean iterations at the noise threshold are included in multiple imaging loops, leading to large fractional changes in the total flux despite being consistent with the noise. We've collectively started hitting chunked imaging cases where a noise-only channel chunk uses all 20 imaging loops and taking way longer to exit than should be needed.

The thinking behind this new test is:
- clean components represent the extremum of the residual image at each iteration. 
- For n_pix finite pixels the extremum is drawn from both tails of the Gaussian, so Var(extremum) ≈ 2·ln(2·n_pix)·(gain·noise)^2.
- the sum S of N_total such extremal draws has Std(S) = sqrt(N_total) · gain · noise · sqrt(2·ln(2·n_pix)).
- we compute the z score = total_flux_iter / Std(S). The criterion passes (null hypothesis) if `z_score < z_threshold`.
-  The threshold is set in `run_imaging` and `loop_imaging` from the image handler with kwarg `convergence_noise_z_threshold`. By default it is None, and this test is not included; passing any finite >0 value enables the noise convergence test, _in addition to_ the existing total flux convergence.

We need the info dict from `fullsummary=True` in tclean and sdintimaging to know the number of iterations actually used, flux per major cycle, etc. The score above defaults to using the last 3 major cycles. There's a future option to correct by scale for multiscale cleaning as this info is also returned in the dictionary.

Trying this on a VLA HI test case for a cube with some low S/N detections, the noise Z-score criterion matches the total flux convergence (the 4 loops is the minimum hardcoded in the PHANGS recipe; otherwise both tests would pass after loop 2):
```
loopnum, deconvolver, niter, cycleniter, threshold, noise, model_flux, frac_delta_flux, noise_z_score
# column 1: Loop number.
# column 2: Deconvolver used in clean.
# column 3: Allocated number of iterations.
# column 4: Cycleniter used to force major cycles.
# column 5: Threshold supplied to clean.
# column 6: Noise level measured in residuals.
# column 7: Integrated model flux.
# column 8: Fractional change in flux from previous loop.
# column 9: Noise z-score.
0, multiscale, 100, 100, 0.02831184606846778Jy/beam, 0.007077961517116945Jy/beam, 1.3617980759704822Jy*chan, inf, 31.32496804221372
1, multiscale, 200, 200, 0.027029895700661062Jy/beam, 0.0067574739251652655Jy/beam, 1.8751552645808185Jy*chan, 0.37697012330149865, 9.468209524700818
2, multiscale, 400, 300, 0.025975869586093447Jy/beam, 0.006493967396523362Jy/beam, 1.8749897100265613Jy*chan, 8.828845130014407e-05, -0.005813716459525169
3, multiscale, 800, 400, 0.025743743418845406Jy/beam, 0.0064359358547113514Jy/beam, 1.8879628674496434Jy*chan, 0.006919055263987687, 0.6851589398047857
```