### PR TITLE
Add action to automatically add Dependabot updates to changelog

### DIFF
--- a/.github/workflows/dependabot-changelog.yml
+++ b/.github/workflows/dependabot-changelog.yml
@@ -1,0 +1,30 @@
+name: 'Add Dependabot Changelog'
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
+      - unlabeled
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+
+      # Retrigger workflows
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.RETRIGGER_WORKFLOW_TOKEN }}
+
+      # Add changelog entry
+      - uses: dangoslen/dependabot-changelog-helper@v4.3.0
+        with:
+          activationLabels: dependencies
+          changelogPath: './CHANGELOG.md'
+          dependencyTool: dependabot
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "Updated Changelog"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Action to automatically add Dependabot updates to changelog (#330)
+- Initial test suite, which checks the various CASA tasks and arguments used throughout the pipeline (#324).
+- Initial pip-installable version (#292).
+
+### Fixed
+
+- Large-cube memory issues with channel-wise processing (#323)
+
+### Dependencies
+
+- Bump actions/upload-artifact from 6 to 7 (#313).
+- Bump casaplotms requirement from >=2.7.4 to >=2.8.2 (#320).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,0 @@
-4.0.0 (Unreleased)
-==================
-
-- Fix large-cube memory issues with channel-wise processing (#323)
-- Added initial test suite, which checks the various CASA tasks and arguments used throughout the pipeline (#324)
-- Bump actions/upload-artifact from 6 to 7 (#313)
-- Bump casaplotms requirement from >=2.7.4 to >=2.8.2 (#320)
-- Initial pip-installable version (#292)


### PR DESCRIPTION
This PR just adds a GH action to automatically add changelog entries when Dependabot pushes an update

- Add action to automatically add Dependabot updates to changelog
