### PR TITLE
Fix crash for different atm types in casaSingleDishALMAWrapper.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't retrigger workflows for dependabot (#332).
 - check-changelog action now uses CHANGELOG.md (#331).
 - Large-cube memory issues with channel-wise processing (#323)
+- Fixed TP crash when different atmospheric correction types are used (#343).
 
 ### Dependencies
 - Bump actions/upload-artifact from 6 to 7 (#313).

--- a/phangsPipeline/casaSingleDishALMAWrapper.py
+++ b/phangsPipeline/casaSingleDishALMAWrapper.py
@@ -293,18 +293,31 @@ def runALMAPipeline(path_galaxy,
     finally:
         h_save()
 
-
-    this_vis = [f"{filename}.ms.atmcor.atmtype1_bl" for filename in EBsnames
-                if os.path.exists(f"{filename}.ms.atmcor.atmtype1_bl")]
-
+    # Find baselined files
+    this_vis = []
     for filename in EBsnames:
-        if os.path.exists(f"{filename}.ms.atmcor.atmtype1_bl"):
-            logger.info(f"Found {filename}.ms.atmcor.atmtype1_bl")
+
+        filename_pattern = f"{filename}.ms.atmcor.atmtype*_bl"
+
+        bl_files = glob.glob(filename_pattern)
+
+        # Add to list if we only have 1 entry
+        if len(bl_files) == 1:
+            bl_file = bl_files[0]
+            logger.info(f"Found {bl_file}")
+            this_vis.append(bl_file)
+
+        # If we don't find anything, log a warning
+        elif len(bl_files) == 0:
+            logger.warning(f"Did not find any files matching pattern: {filename_pattern}")
+
+        # We should only find one file, so crash if there's too many
         else:
-            logger.warning(f"Did not find {filename}.ms.atmcor.atmtype1_bl")
+            logger.error(f"Found more than one file matching pattern {filename_pattern}: {bl_files}")
+            raise ValueError(f"Found more than one file matching pattern {filename_pattern}: {bl_files}")
 
     if len(this_vis) == 0:
-        logger.info("No valid MSs found for imaging.")
+        logger.error("No valid MSs found for imaging.")
         raise ValueError("No valid MSs found for imaging.")
 
     # Avoid too many files open issues


### PR DESCRIPTION
Fixes #311.

This PR fixes a crash when TP data uses different atmospheric types. I think this happens in the `hsd_atmcor` call in the TP pipeline but what matters is that dependending on the model, the output filename is different. This just fixes that to search more generally. It'll warn if no files are found for a particular EB, and will raise an Error if multiple files are found for a particular EB.

- Use glob to find baselined files for different atmtypes
- Updated changelog
