### PR TITLE
BUGFIX: cleanmask support for sdintimaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Calculation of additional number of channels in regrid mstransform call (#344).
 - Fix stokes passed as integer string to imsubimage in 4D mosaic path (#349).
 - Import recipe_phangs_flat_mask in handlerDerived (#357).
+- Fix crash with using cleanmasks combined with new sdintimaging implementation (#360)
 
 ### Dependencies
 - Bump actions/upload-artifact from 6 to 7 (#313).

--- a/phangsPipeline/handlerImaging.py
+++ b/phangsPipeline/handlerImaging.py
@@ -817,10 +817,17 @@ if casa_enabled:
                                           imaging_method=imaging_method)
 
             # import_and_align_mask
-            msr.import_and_align_mask(in_file=this_cleanmask,
-                                      out_file=fname_dict['mask'],
-                                      template=fname_dict['image'],
-                                      blank_to_match=True)
+            if imaging_method == 'tclean':
+                msr.import_and_align_mask(in_file=this_cleanmask,
+                                          out_file=fname_dict['mask'],
+                                          template=fname_dict['image'],
+                                          blank_to_match=True)
+            elif imaging_method == 'sdintimaging':
+                template_name = fname_dict['image'].replace('.joint.', '.sd.')
+                msr.import_and_align_mask(in_file=this_cleanmask,
+                                          out_file=fname_dict['mask'],
+                                          template=template_name,
+                                          blank_to_match=True)
             # AKL - propose to deprecate
             # clean_call.set_param('usemask','user')
 


### PR DESCRIPTION
The new sdintimaging code crashes out when a cleanmask is used.  It tries to use the joint cube as a header template for aligning the clean mask. That cube doesn't exist at the time when the alignment code is called.  This bug fix uses the regridded single dish cube as a header template instead. 